### PR TITLE
Adding axis2 TCP Persistance Support

### DIFF
--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPConstants.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPConstants.java
@@ -25,9 +25,17 @@ public class TCPConstants {
     public static final String PARAM_HOST = "transport.tcp.hostname";
     public static final String PARAM_BACKLOG = "transport.tcp.backlog";
     public static final String PARAM_CONTENT_TYPE = "transport.tcp.contentType";
-
+    public static final String PARAM_RECORD_DELIMITER = "transport.tcp.recordDelimiter";
+    public static final String PARAM_RECORD_DELIMITER_TYPE = "transport.tcp.recordDelimiterType";
+    public static final String PARAM_RECORD_LENGTH = "transport.tcp.recordLength";
+    public static final String PARAM_RESPONSE_CLIENT = "transport.tcp.responseClient";
+    public static final String PARAM_RESPONSE_INPUT_TYPE = "transport.tcp.inputType";
+    public static final String BINARY_INPUT_TYPE = "binary";
+    public static final String STRING_INPUT_TYPE = "string";
+    public static final String STRING_DELIMITER_TYPE = "string";
+    public static final String BYTE_DELIMITER_TYPE = "byte";
+    public static final String CHARACTER_DELIMITER_TYPE = "character";
     public static final int TCP_DEFAULT_BACKLOG = 50;
     public static final String TCP_DEFAULT_CONTENT_TYPE = "text/xml";
-
     public static final String TCP_OUTPUT_SOCKET = "transport.tcp.outputSocket";
 }

--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPEndpoint.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPEndpoint.java
@@ -36,6 +36,11 @@ public class TCPEndpoint extends ProtocolEndpoint {
     private int port = -1;
     private int backlog = TCPConstants.TCP_DEFAULT_BACKLOG;
     private String contentType;
+    private String recordDelimiter;
+    private String recordDelimiterType;
+    private Integer recordLength;
+    private boolean clientResponseRequired;
+    private String inputType;
 
     public TCPEndpoint() {
 
@@ -63,6 +68,38 @@ public class TCPEndpoint extends ProtocolEndpoint {
         return contentType;
     }
 
+    public String getRecordDelimiter() {
+        return recordDelimiter;
+    }
+
+    public Integer getRecordLength() {
+        return recordLength;
+    }
+
+    public boolean isClientResponseRequired() {
+		return clientResponseRequired;
+	}
+
+    public void setClientResponseRequired(boolean clientResponseRequired) {
+        this.clientResponseRequired = clientResponseRequired;
+    }
+
+    public String getInputType() {
+    	return inputType;
+    }
+
+    public void setInputType(String inputType) {
+    	this.inputType = inputType;
+    }
+
+    public String getRecordDelimiterType() {
+        return recordDelimiterType;
+    }
+
+    public void setRecordDelimiterType(String recordDelimiterType) {
+        this.recordDelimiterType = recordDelimiterType;
+    }
+
     public boolean loadConfiguration(ParameterInclude params) throws AxisFault {
         port = ParamUtils.getOptionalParamInt(params, TCPConstants.PARAM_PORT, -1);
         if (port == -1) {
@@ -70,13 +107,34 @@ public class TCPEndpoint extends ProtocolEndpoint {
         }
 
         contentType = ParamUtils.getOptionalParam(params, TCPConstants.PARAM_CONTENT_TYPE);
-        if (contentType == null) {
+        if (contentType == null || contentType.isEmpty()) {
             contentType = TCPConstants.TCP_DEFAULT_CONTENT_TYPE;
         }
+        
+        recordDelimiter = ParamUtils.getOptionalParam(params, TCPConstants.PARAM_RECORD_DELIMITER);
+        if (recordDelimiter == null) {
+        	recordDelimiter = "";
+        }
+        
+        recordLength =  ParamUtils.getOptionalParamInt(params, TCPConstants.PARAM_RECORD_LENGTH);
+        if(recordLength == null){
+        	recordLength = -1;
+        }
+        
+        inputType  =  ParamUtils.getOptionalParam(params, TCPConstants.PARAM_RESPONSE_INPUT_TYPE);
+        if(inputType == null || inputType.isEmpty()){
+        	inputType = TCPConstants.BINARY_INPUT_TYPE;
+        }
+
+        recordDelimiterType  =  ParamUtils.getOptionalParam(params, TCPConstants.PARAM_RECORD_DELIMITER_TYPE);
+        if(recordDelimiterType == null || recordDelimiterType.isEmpty() ){
+            recordDelimiterType = TCPConstants.CHARACTER_DELIMITER_TYPE;
+        }
+
+        clientResponseRequired =  ParamUtils.getOptionalParamBoolean(params, TCPConstants.PARAM_RESPONSE_CLIENT, false);
 
         host = ParamUtils.getOptionalParam(params, TCPConstants.PARAM_HOST);
-        backlog = ParamUtils.getOptionalParamInt(params, TCPConstants.PARAM_BACKLOG,
-                TCPConstants.TCP_DEFAULT_BACKLOG);
+        backlog = ParamUtils.getOptionalParamInt(params, TCPConstants.PARAM_BACKLOG, TCPConstants.TCP_DEFAULT_BACKLOG);
         return true;
     }
 
@@ -100,8 +158,7 @@ public class TCPEndpoint extends ProtocolEndpoint {
         if (!contentType.equals(TCPConstants.TCP_DEFAULT_CONTENT_TYPE)) {
             url += "?contentType=" + contentType;
         }
-
         return new EndpointReference[] { new EndpointReference(url) };
     }
-    
+
 }

--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPOutTransportInfo.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPOutTransportInfo.java
@@ -1,47 +1,72 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
+ *  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
  */
-
 package org.apache.axis2.transport.tcp;
 
 import org.apache.axis2.transport.OutTransportInfo;
 
-import java.io.OutputStream;
 import java.net.Socket;
 
 public class TCPOutTransportInfo implements OutTransportInfo {
 
-    private Socket socket;
-    private String contentType;
+	private Socket socket;
+	private String contentType;
+	private boolean clientResponseRequired = false;
+	private String delimiter;
+	private String delimiterType;
 
-    public Socket getSocket() {
-        return socket;
-    }
+	public Socket getSocket() {
+		return socket;
+	}
 
-    public void setSocket(Socket socket) {
-        this.socket = socket;
-    }
+	public void setSocket(Socket socket) {
+		this.socket = socket;
+	}
 
-    public void setContentType(String contentType) {
-        this.contentType = contentType;
-    }
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
 
-    public String getContentType() {
-        return contentType;
-    }
+	public String getContentType() {
+		return contentType;
+	}
+
+	public boolean isClientResponseRequired() {
+		return clientResponseRequired;
+	}
+
+	public void setClientResponseRequired(boolean clientResponseRequired) {
+		this.clientResponseRequired = clientResponseRequired;
+	}
+
+	public String getDelimiter() {
+		return delimiter;
+	}
+
+	public void setDelimiter(String delimiter) {
+		this.delimiter = delimiter;
+	}
+
+	public String getDelimiterType() {
+		return delimiterType;
+	}
+
+	public void setDelimiterType(String delimiterType) {
+		this.delimiterType = delimiterType;
+	}
 }

--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPWorker.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPWorker.java
@@ -83,22 +83,22 @@ public class TCPWorker implements Runnable {
 			if (!delimiter.isEmpty() && !handled) {
 				if (inputType != null) {
 					if (TCPConstants.STRING_INPUT_TYPE.equalsIgnoreCase(inputType)) {
-						if(TCPConstants.CHARACTER_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
-							this.handleCharacterRecordDelimiterStringStream(msgContext, input, delimiter.charAt(0));
+						if(TCPConstants.BYTE_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
+							int delimiterVal = Integer.parseInt(delimiter.split("0x")[1], 16);
+							this.handleCharacterRecordDelimiterStringStream(msgContext, input, delimiterVal);
 						} else if(TCPConstants.STRING_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
 							this.handleStringRecordDelimiterStringStream(msgContext, input, delimiter);
 						} else {
-							int delimiterVal = Integer.parseInt(delimiter.split("0x")[1], 16);
-							this.handleCharacterRecordDelimiterStringStream(msgContext, input, delimiterVal);
+							this.handleCharacterRecordDelimiterStringStream(msgContext, input, delimiter.charAt(0));
 						}
 					} else {
-						if(TCPConstants.CHARACTER_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
-							this.handleCharacterRecordDelimiterBinaryStream(msgContext, input, delimiter.charAt(0));
+						if(TCPConstants.BYTE_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
+							int delimiterVal = Integer.parseInt(delimiter.split("0x")[1], 16);
+							this.handleCharacterRecordDelimiterBinaryStream(msgContext, input, delimiterVal);
 						} else if(TCPConstants.STRING_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
 							this.handleStringRecordDelimiterBinaryStream(msgContext, input, delimiter);
 						} else {
-							int delimiterVal = Integer.parseInt(delimiter.split("0x")[1], 16);
-							this.handleCharacterRecordDelimiterBinaryStream(msgContext, input, delimiterVal);
+							this.handleCharacterRecordDelimiterBinaryStream(msgContext, input, delimiter.charAt(0));
 						}
 					}
 				}
@@ -240,7 +240,7 @@ public class TCPWorker implements Runnable {
 					if(next > -1) {
 						bos.write(next);
 					}
-					String[] segments = bos.toString("UTF-8").split(delimiter);
+					String[] segments = bos.toString().split(delimiter);
 					for(String s : segments) {
 						handleEnvelope(msgContext, s.getBytes());
 					}

--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPWorker.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPWorker.java
@@ -20,6 +20,7 @@
 package org.apache.axis2.transport.tcp;
 
 import org.apache.axiom.soap.SOAPEnvelope;
+import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.axis2.transport.TransportUtils;
 import org.apache.axis2.context.MessageContext;
@@ -28,8 +29,17 @@ import org.apache.axis2.util.MessageContextBuilder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StreamTokenizer;
 import java.net.Socket;
+import java.util.Arrays;
+
+import javax.xml.parsers.FactoryConfigurationError;
+import javax.xml.stream.XMLStreamException;
 
 /**
  * This Class is the work hoarse of the TCP request, this process the incomming SOAP Message.
@@ -46,38 +56,316 @@ public class TCPWorker implements Runnable {
         this.socket = socket;
     }
 
-    public void run() {
+	public void run() {
+		MessageContext msgContext = null;
+		try {
+			msgContext = endpoint.createMessageContext();
+			msgContext.setIncomingTransportName(Constants.TRANSPORT_TCP);
+			TCPOutTransportInfo outInfo = new TCPOutTransportInfo();
+			outInfo.setSocket(socket);
+			outInfo.setClientResponseRequired(endpoint.isClientResponseRequired());
+			outInfo.setContentType(endpoint.getContentType());
+			String delimiter = endpoint.getRecordDelimiter();
+			int recordLength = endpoint.getRecordLength();
+			String inputType = endpoint.getInputType();
+			String delimiterType = endpoint.getRecordDelimiterType();
+			outInfo.setDelimiter(delimiter);
+			outInfo.setDelimiterType(delimiterType);
+			msgContext.setProperty(Constants.OUT_TRANSPORT_INFO, outInfo);
+			// create the SOAP Envelope
+			InputStream input = socket.getInputStream();
+			boolean handled = false;
+			if  (recordLength > -1) {
+				this.handleRecordLength(msgContext, input, recordLength);
+				handled = true;
+			}
+			
+			if (!delimiter.isEmpty() && !handled) {
+				if (inputType != null) {
+					if (TCPConstants.STRING_INPUT_TYPE.equalsIgnoreCase(inputType)) {
+						if(TCPConstants.CHARACTER_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
+							this.handleCharacterRecordDelimiterStringStream(msgContext, input, delimiter.charAt(0));
+						} else if(TCPConstants.STRING_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
+							this.handleStringRecordDelimiterStringStream(msgContext, input, delimiter);
+						} else {
+							int delimiterVal = Integer.parseInt(delimiter.split("0x")[1], 16);
+							this.handleCharacterRecordDelimiterStringStream(msgContext, input, delimiterVal);
+						}
+					} else {
+						if(TCPConstants.CHARACTER_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
+							this.handleCharacterRecordDelimiterBinaryStream(msgContext, input, delimiter.charAt(0));
+						} else if(TCPConstants.STRING_DELIMITER_TYPE.equalsIgnoreCase(delimiterType)) {
+							this.handleStringRecordDelimiterBinaryStream(msgContext, input, delimiter);
+						} else {
+							int delimiterVal = Integer.parseInt(delimiter.split("0x")[1], 16);
+							this.handleCharacterRecordDelimiterBinaryStream(msgContext, input, delimiterVal);
+						}
+					}
+				}
+				handled = true;
+			}
+			
+			if (!handled) {
+				SOAPEnvelope envelope = TransportUtils.createSOAPMessage(msgContext, input,
+						endpoint.getContentType());
+				msgContext.setEnvelope(envelope);
+				AxisEngine.receive(msgContext);
+			}
+		} catch (Exception e) {
+			sendFault(msgContext, e);
+		} finally {
+			if (!endpoint.isClientResponseRequired()) {
+				try {
+					socket.close();
+				} catch (IOException e) {
+					log.error("Error while closing a TCP socket", e);
+				}
+			}
+		}
+	}
 
-        MessageContext msgContext = null;
+	/**
+	 * Handling record delimiter character type for string stream
+	 * 
+	 * @param msgContext the messahe contenxt
+	 * @param input socket input stream
+	 * @param delimiter character value to delimit incoming message
+	 * @throws XMLStreamException if xml parsing error occurred
+	 * @throws FactoryConfigurationError if configuration issue occurred
+	 */
+	private void handleCharacterRecordDelimiterStringStream(MessageContext msgContext, InputStream input,
+	                                                        int delimiter) throws AxisFault {
+		log.debug("Handle message with character delimiter type string stream");
+		StreamTokenizer tokenizer = new StreamTokenizer(new InputStreamReader(input));
+		tokenizer.resetSyntax();
+		tokenizer.wordChars('\u0000', (char) (delimiter - 1));
+		tokenizer.wordChars((char) (delimiter + 1), '\u00ff');
+		tokenizer.whitespaceChars('\n', '\n');
+		tokenizer.whitespaceChars(delimiter, delimiter);
+		tokenizer.eolIsSignificant(true);
+		int type = 0; // Stores the value returned by nextToken()
+		try {
+			type = tokenizer.nextToken();
+			while (type != StreamTokenizer.TT_EOF) {
+				if (type == StreamTokenizer.TT_WORD) {
+					handleEnvelope(msgContext, tokenizer.sval.getBytes());
+				} else {
+					assert false; // We only expect words
+				}
+				type = tokenizer.nextToken();
+			}
+		} catch (IOException e) {
+			sendFault(msgContext, e);
+		}
+	}
+	
+	/**
+	 * Handling record delimiter character type in binary stream
+	 * 
+	 * @param msgContext the message context
+	 * @param input socket input stream
+	 * @param delimiter character value to delimit incoming message
+	 * @throws AxisFault if error occurred while processing
+	 */
+	private void handleCharacterRecordDelimiterBinaryStream(MessageContext msgContext, InputStream input,
+	                                                        int delimiter) throws AxisFault {
+		log.debug("Handle message with character delimiter type binary stream");
+		ByteArrayOutputStream bos = null;
+		try {
+			int next = input.read();
+			while (next > -1) {
+				if (next == delimiter && bos != null) {
+					try {
+						bos.flush();
+					} catch (IOException e) {
+						sendFault(msgContext, e);
+					}
+					byte[] result = bos.toByteArray();
+					handleEnvelope(msgContext, result);
+					bos.close();
+					bos = null;
+					next = input.read();
+					continue;
+				}
 
-        try {
-            msgContext = endpoint.createMessageContext();
-            msgContext.setIncomingTransportName(Constants.TRANSPORT_TCP);
-            //msgContext.setTransportIn(endpoint.getListener().getTransportInDescription());
+				if (bos == null) {
+					bos = new ByteArrayOutputStream();
+				}
 
-            TCPOutTransportInfo outInfo = new TCPOutTransportInfo();
-            outInfo.setSocket(socket);
-            outInfo.setContentType(endpoint.getContentType());
-            msgContext.setProperty(Constants.OUT_TRANSPORT_INFO, outInfo);
+				if (next != delimiter) {
+					bos.write(next);
+				}
+				next = input.read();
+			}
+			if (bos != null) {
+				handleEnvelope(msgContext, bos.toByteArray());
+			}
+		} catch (IOException e) {
+			sendFault(msgContext, e);
+		} finally {
+			if (bos != null) {
+				try {
+					bos.close();
+				} catch (IOException e) {
+					sendFault(msgContext, e);
+				}
+			}
+		}
+	}
 
-            // create the SOAP Envelope
-            SOAPEnvelope envelope = TransportUtils.createSOAPMessage(msgContext,
-                    socket.getInputStream(), endpoint.getContentType());
-            msgContext.setEnvelope(envelope);
+	/**
+	 * Handling record string type delimiter in string stream
+	 *
+	 * @param msgContext the message context
+	 * @param input socket input stream
+	 * @param delimiter delimiter string
+	 * @throws AxisFault if error occurred while processing
+	 */
+	private void handleStringRecordDelimiterStringStream(MessageContext msgContext, InputStream input,
+	                                                     String delimiter) throws AxisFault {
+		log.debug("Handle message with string delimiter type string stream");
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		try {
+			int next = input.read();
+			while(next > -1) {
+				bos.write(next);
+				next = input.read();
+				if(input.available() <= 0) {
+					if(next > -1) {
+						bos.write(next);
+					}
+					String[] segments = bos.toString("UTF-8").split(delimiter);
+					for(String s : segments) {
+						handleEnvelope(msgContext, s.getBytes());
+					}
+					bos = new ByteArrayOutputStream();
+					next = input.read();
+				}
+			}
+		} catch (IOException e) {
+			sendFault(msgContext, e);
+		} finally {
+				try {
+					bos.close();
+				} catch (IOException e) {
+					sendFault(msgContext, e);
+				}
+		}
+	}
 
-            AxisEngine.receive(msgContext);
+	/**
+	 * Handling record delimiter string type delimiter in binary stream
+	 *
+	 * @param msgContext the message context
+	 * @param input socket input stream
+	 * @param delimiter delimiter string
+	 * @throws AxisFault if error occurred while processing
+	 */
+	private void handleStringRecordDelimiterBinaryStream(MessageContext msgContext, InputStream input,
+	                                                     String delimiter) throws AxisFault {
+		log.debug("Handle message with string delimiter type binary stream");
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		ByteArrayOutputStream chunk = new ByteArrayOutputStream();
+		try {
+			int next = input.read();
+			while(next > -1) {
+				bos.write(next);
+				next = input.read();
+				if(input.available() <= 0) {
+					if (next > -1) {
+						bos.write(next);
+					}
+					byte[] contents = bos.toByteArray();
+					byte[] delimiterBytes = delimiter.getBytes();
+					for(int i = 0; i< (contents.length - delimiterBytes.length + 1); i++) {
+						byte[] temp = new  byte[delimiterBytes.length];
+						int count = 0;
+						for(int j = i; j < (i + delimiterBytes.length); j++) {
+							temp[count] = contents[j];
+							count++;
+						}
+						if(Arrays.equals(delimiterBytes, temp)) {
+							handleEnvelope(msgContext, chunk.toByteArray());
+							chunk = new ByteArrayOutputStream();
+							i = i + delimiterBytes.length - 1;
+						} else {
+							chunk.write(contents[i]);
+						}
+					}
+					bos =new ByteArrayOutputStream();
+					next = input.read();
+				}
+			}
+		} catch (IOException e) {
+			sendFault(msgContext, e);
+		} finally {
+			try {
+				bos.close();
+				chunk.close();
+			} catch (IOException e) {
+				sendFault(msgContext, e);
+			}
+		}
+	}
 
-        } catch (Exception e) {
-            sendFault(msgContext, e);
+	/**
+	 * Handling record length delimiter
+	 * @param msgContext the message context
+	 * @param input the socket input stream
+	 * @param recordLength the record length to split the message
+	 * @throws AxisFault if error occurred while processing
+	 */
+	private void handleRecordLength(MessageContext msgContext, InputStream input,
+			int recordLength) throws AxisFault {
+		ByteArrayOutputStream baos = null;
+		byte[] bytes = new byte[recordLength];
+			try {
+				for (int len; (len = input.read(bytes)) > 0;) {
+					baos = new ByteArrayOutputStream();
+					baos.write(bytes, 0, len);
+					ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+					SOAPEnvelope envelope = TransportUtils.createSOAPMessage(msgContext, bais,
+							endpoint.getContentType());
+					msgContext.setEnvelope(envelope);
+					AxisEngine.receive(msgContext);
+				}
+			} catch (IOException e) {
+				sendFault(msgContext, e);
+			} catch (XMLStreamException e) {
+				sendFault(msgContext, e);
+			} finally {
+				if(baos != null) {
+					try {
+						baos.close();
+					} catch (IOException e) {
+						sendFault(msgContext, e);
+					}
+				}
+			}
+		}
 
-        } finally {
-            try {
-                socket.close();
-            } catch (IOException e) {
-                log.error("Error while closing a TCP socket", e);
-            }
-        }
-    }
+	private void handleEnvelope(MessageContext msgContext, byte [] value) throws AxisFault {
+		ByteArrayInputStream bais = null;
+		try {
+			bais = new ByteArrayInputStream(value);
+			SOAPEnvelope envelope = TransportUtils.createSOAPMessage(msgContext,
+					bais, endpoint.getContentType());
+			msgContext.setEnvelope(envelope);
+			AxisEngine.receive(msgContext);
+		} catch (IOException e) {
+			sendFault(msgContext, e);
+		} catch (XMLStreamException e) {
+			sendFault(msgContext, e);
+		} finally {
+			if(bais != null) {
+				try {
+					bais.close();
+				} catch (IOException e) {
+					sendFault(msgContext, e);
+				}
+			}
+		}
+	}
 
     private void sendFault(MessageContext msgContext, Exception fault) {
         log.error("Error while processing TCP request through the Axis2 engine", fault);

--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPWorker.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPWorker.java
@@ -135,7 +135,9 @@ public class TCPWorker implements Runnable {
 	 */
 	private void handleCharacterRecordDelimiterStringStream(MessageContext msgContext, InputStream input,
 	                                                        int delimiter) throws AxisFault {
-		log.debug("Handle message with character delimiter type string stream");
+		if(log.isDebugEnabled()) {
+			log.debug("Handle message with character delimiter type string stream");
+		}
 		StreamTokenizer tokenizer = new StreamTokenizer(new InputStreamReader(input));
 		tokenizer.resetSyntax();
 		tokenizer.wordChars('\u0000', (char) (delimiter - 1));
@@ -169,7 +171,9 @@ public class TCPWorker implements Runnable {
 	 */
 	private void handleCharacterRecordDelimiterBinaryStream(MessageContext msgContext, InputStream input,
 	                                                        int delimiter) throws AxisFault {
-		log.debug("Handle message with character delimiter type binary stream");
+		if(log.isDebugEnabled()) {
+			log.debug("Handle message with character delimiter type binary stream");
+		}
 		ByteArrayOutputStream bos = null;
 		try {
 			int next = input.read();
@@ -223,7 +227,9 @@ public class TCPWorker implements Runnable {
 	 */
 	private void handleStringRecordDelimiterStringStream(MessageContext msgContext, InputStream input,
 	                                                     String delimiter) throws AxisFault {
-		log.debug("Handle message with string delimiter type string stream");
+		if(log.isDebugEnabled()) {
+			log.debug("Handle message with string delimiter type string stream");
+		}
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		try {
 			int next = input.read();
@@ -263,10 +269,13 @@ public class TCPWorker implements Runnable {
 	 */
 	private void handleStringRecordDelimiterBinaryStream(MessageContext msgContext, InputStream input,
 	                                                     String delimiter) throws AxisFault {
-		log.debug("Handle message with string delimiter type binary stream");
+		if(log.isDebugEnabled()) {
+			log.debug("Handle message with string delimiter type binary stream");
+		}
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
 		ByteArrayOutputStream chunk = new ByteArrayOutputStream();
 		try {
+			byte[] delimiterBytes = delimiter.getBytes();
 			int next = input.read();
 			while(next > -1) {
 				bos.write(next);
@@ -276,7 +285,6 @@ public class TCPWorker implements Runnable {
 						bos.write(next);
 					}
 					byte[] contents = bos.toByteArray();
-					byte[] delimiterBytes = delimiter.getBytes();
 					for(int i = 0; i< (contents.length - delimiterBytes.length + 1); i++) {
 						byte[] temp = new  byte[delimiterBytes.length];
 						int count = 0;
@@ -318,12 +326,13 @@ public class TCPWorker implements Runnable {
 	private void handleRecordLength(MessageContext msgContext, InputStream input,
 			int recordLength) throws AxisFault {
 		ByteArrayOutputStream baos = null;
+		ByteArrayInputStream bais = null;
 		byte[] bytes = new byte[recordLength];
 			try {
 				for (int len; (len = input.read(bytes)) > 0;) {
 					baos = new ByteArrayOutputStream();
 					baos.write(bytes, 0, len);
-					ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+					bais = new ByteArrayInputStream(baos.toByteArray());
 					SOAPEnvelope envelope = TransportUtils.createSOAPMessage(msgContext, bais,
 							endpoint.getContentType());
 					msgContext.setEnvelope(envelope);
@@ -340,6 +349,13 @@ public class TCPWorker implements Runnable {
 					} catch (IOException e) {
 						sendFault(msgContext, e);
 					}
+				if(bais != null) {
+					try {
+						bais.close();
+					} catch (IOException e) {
+						sendFault(msgContext, e);
+					}
+				}
 				}
 			}
 		}


### PR DESCRIPTION
With the TCP session persistance support client can send and receive messages to the TCP Proxy through same TCP Connection.  In TCP transport, there will be need of determining the end of message which needs to be mediated through the ESB. So with the implementation ESB will support splitting message with character, sequence of characters, message length and special characters in hex form. There is a option that client can select which input type where client send the request to tcp proxy. For now the options available for the input type is binary and string. Splitting the message by single character will be the most efficient.

By default without these properties, ESB will close the tcp session after each request with transport.tcp.responseClient set to false. If it set to true, the connection will not be closed.

Available properties.

"transport.tcp.port" - TCP Port
"transport.tcp.contentType" - Input message content type
"transport.tcp.recordDelimiter" - record delimiter
"transport.tcp.recordDelimiterType" -type of delimiter (string, character, byte)
"transport.tcp.recordLength" - Length of message to splitted. If this is set then delimiter properties will be omitted
"transport.tcp.responseClient - Set if client need to get the response;
"transport.tcp.inputType" - Input type of message (string, binary)