### PR TITLE
Adding support for mailto transport with suffixes for its name

### DIFF
--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailConstants.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailConstants.java
@@ -25,6 +25,7 @@ public class MailConstants {
 
     public static final String TRANSPORT_NAME = "mailto";
     public static final String TRANSPORT_PREFIX = "mailto:";
+    public static final String TRANSPORT_SPLITTER = ":";
     
     public static final String TEXT_PLAIN = "text/plain";
     public static final String APPLICATION_BINARY = "application/binary";

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailTransportSender.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailTransportSender.java
@@ -141,7 +141,14 @@ public class MailTransportSender extends AbstractTransportSender
 
         if (targetAddress != null) {
             if (targetAddress.startsWith(MailConstants.TRANSPORT_NAME)) {
-                targetAddress = targetAddress.substring(MailConstants.TRANSPORT_NAME.length()+1);
+                int startIndex = targetAddress.indexOf(MailConstants.TRANSPORT_SPLITTER);
+                if (startIndex > 0) {
+                    /*
+                     Support any suffix added until MailConstants.TRANSPORT_SPLITTER (eg: mailtoWSO2)
+                     This will support using multiple inbox with mailto transport
+                      */
+                    targetAddress = targetAddress.substring(startIndex + 1);
+                }
             }
 
             if (msgCtx.getReplyTo() != null &&


### PR DESCRIPTION
This will allow to add multiple sender email to TransportSender via axis2 configuration. Eg:

```
    <transportSender name="mailtoWSO2" class="org.apache.axis2.transport.mail.MailTransportSender">
        <parameter name="mail.smtp.host">smtp.gmail.com</parameter>
        <parameter name="mail.smtp.port">587</parameter>
        <parameter name="mail.smtp.starttls.enable">true</parameter>
        <parameter name="mail.smtp.auth">true</parameter>
        <parameter name="mail.smtp.user">synapse.demo.0</parameter>
        <parameter name="mail.smtp.password">mailpassword</parameter>
        <parameter name="mail.smtp.from">synapse.demo.0@gmail.com</parameter>
    </transportSender>
```

Using in synapse configuration : 
```
      <endpoint>
         <address uri="mailtoWSO2:user@host"/>
      </endpoint>
```