### PR TITLE
[ESBJAVA-5048] Fix : RabbitMQ sender set unknown value for SOAP Action

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
@@ -287,7 +287,9 @@ public class RabbitMQMessageSender {
         builder.correlationId(message.getCorrelationId());
         builder.contentEncoding(message.getContentEncoding());
         Map<String, Object> headers = message.getHeaders();
-        headers.put(RabbitMQConstants.SOAP_ACTION, message.getSoapAction());
+        if (message.getSoapAction() != null) {
+            headers.put(RabbitMQConstants.SOAP_ACTION, message.getSoapAction());
+        }
         builder.headers(headers);
         return builder;
     }

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
@@ -364,7 +364,9 @@ public class RabbitMQRPCMessageSender {
         builder.correlationId(message.getCorrelationId());
         builder.contentEncoding(message.getContentEncoding());
         Map<String, Object> headers = message.getHeaders();
-        headers.put(RabbitMQConstants.SOAP_ACTION, message.getSoapAction());
+        if (message.getSoapAction() != null) {
+            headers.put(RabbitMQConstants.SOAP_ACTION, message.getSoapAction());
+        }
         builder.headers(headers);
         return builder;
     }


### PR DESCRIPTION
When the message is of non-SOAP (e.g. JSON), RabbitMQ sender has set unknown value for SOAP Action. This PR contains the fix for this.