### PR TITLE
Fix JMS transport parameter decryption

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactoryManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactoryManager.java
@@ -15,16 +15,16 @@
 */
 package org.apache.axis2.transport.jms;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.naming.Context;
-
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.description.Parameter;
 import org.apache.axis2.description.ParameterInclude;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.securevault.SecretResolver;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.naming.Context;
 
 /**
  * Class managing a set of {@link JMSConnectionFactory} objects.
@@ -38,27 +38,29 @@ public class JMSConnectionFactoryManager {
         new HashMap<String,JMSConnectionFactory>();
 
     /**
-     * Construct a Connection factory manager for the JMS transport sender or receiver
-     * @param trpInDesc
+     * Construct a Connection factory manager for the JMS transport sender or receiver.
+     *
+     * @param trpInDesc the transport description for JMS
+     * @param secretResolver the SecretResolver to use to resolve secrets such as passwords
      */
-    public JMSConnectionFactoryManager(ParameterInclude trpInDesc) {
-        loadConnectionFactoryDefinitions(trpInDesc);
+    public JMSConnectionFactoryManager(ParameterInclude trpInDesc, SecretResolver secretResolver) {
+        loadConnectionFactoryDefinitions(trpInDesc, secretResolver);
     }
 
     /**
      * Create JMSConnectionFactory instances for the definitions in the transport configuration,
-     * and add these into our collection of connectionFactories map keyed by name
+     * and add these into our collection of connectionFactories map keyed by name.
      *
      * @param trpDesc the transport description for JMS
+     * @param secretResolver the SecretResolver to use to resolve secrets such as passwords
      */
-    private void loadConnectionFactoryDefinitions(ParameterInclude trpDesc) {
-
-        for (Parameter p : trpDesc.getParameters()) {
+    private void loadConnectionFactoryDefinitions(ParameterInclude trpDesc, SecretResolver secretResolver) {
+        for (Parameter parameter : trpDesc.getParameters()) {
             try {
-                JMSConnectionFactory jmsConFactory = new JMSConnectionFactory(p);
+                JMSConnectionFactory jmsConFactory = new JMSConnectionFactory(parameter, secretResolver);
                 connectionFactories.put(jmsConFactory.getName(), jmsConFactory);
             } catch (AxisJMSException e) {
-                log.error("Error setting up connection factory : " + p.getName(), e);
+                log.error("Error setting up connection factory : " + parameter.getName(), e);
             }
         }
     }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -390,4 +390,9 @@ public class JMSConstants {
      * Parameter for jndi security credentials in jms configs of axis2.xml
      */
     public static final String PARAM_NAMING_SECURITY_CREDENTIALS = "java.naming.security.credentials";
+
+    /**
+     * Qualified name for SecureVault aliases.
+     */
+    public static final QName ALIAS_QNAME = new QName("http://org.wso2.securevault/configuration", "secretAlias");
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSListener.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSListener.java
@@ -25,6 +25,7 @@ import org.apache.axis2.transport.base.ManagementSupport;
 import org.apache.axis2.transport.base.event.TransportErrorListener;
 import org.apache.axis2.transport.base.event.TransportErrorSource;
 import org.apache.axis2.transport.base.event.TransportErrorSourceSupport;
+import org.wso2.securevault.SecretResolver;
 
 import java.util.Hashtable;
 import javax.jms.Connection;
@@ -59,10 +60,14 @@ public class JMSListener extends AbstractTransportListenerEx<JMSEndpoint> implem
     private JMSConnectionFactoryManager connFacManager;
 
     private final TransportErrorSourceSupport tess = new TransportErrorSourceSupport(this);
-    
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void doInit() throws AxisFault {
-        connFacManager = new JMSConnectionFactoryManager(getTransportInDescription());
+        SecretResolver secretResolver = getConfigurationContext().getAxisConfiguration().getSecretResolver();
+        connFacManager = new JMSConnectionFactoryManager(getTransportInDescription(), secretResolver);
         log.info("JMS Transport Receiver/Listener initialized...");
     }
 

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -34,6 +34,7 @@ import org.apache.axis2.transport.http.HTTPConstants;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageOutputStream;
 import org.apache.axis2.util.MessageProcessorSelector;
 import org.apache.commons.io.output.WriterOutputStream;
+import org.wso2.securevault.SecretResolver;
 
 import javax.activation.DataHandler;
 import javax.jms.*;
@@ -72,7 +73,8 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
     @Override
     public void init(ConfigurationContext cfgCtx, TransportOutDescription transportOut) throws AxisFault {
         super.init(cfgCtx, transportOut);
-        connFacManager = new JMSConnectionFactoryManager(transportOut);
+        SecretResolver secretResolver = cfgCtx.getAxisConfiguration().getSecretResolver();
+        connFacManager = new JMSConnectionFactoryManager(transportOut, secretResolver);
         log.info("JMS Transport Sender initialized...");
     }
     


### PR DESCRIPTION
This PR introduces decryption of parameters specified for the JMS transport encrypted using SecureVault.
Ports the fix previously done for RabbitMQ (https://github.com/wso2/wso2-axis2-transports/pull/111/files).

Resolves wso2/product-ei#947