### PR TITLE
Fix JMS transport consumer recovery when Exception Listener is not notified 

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -112,7 +112,7 @@ public class JMSConstants {
 	 * Duration in milliseconds to try reconnecting when the MQ is
 	 * down(shutdown)
 	 */
-	public static final String PARAM_RECONNECT_INTERVAL = "transport.jms.ReconnectInterval";     
+	public static final String PARAM_RECONNECT_INTERVAL = "transport.jms.ReconnectInterval";
     /**
      * The Parameter indicating the expected content type for messages received by the service.
      */
@@ -176,6 +176,10 @@ public class JMSConstants {
      * Maximum retries on consume error before delay kicks in.
      */
     public static final String PARAM_MAX_CONSUME_RETRY_BEFORE_DELAY = "transport.jms.MaxConsumeErrorRetriesBeforeDelay";
+    /**
+     * Maximum retries on consumer error.
+     */
+    public static final String PARAM_MAX_CONSUME_RETRY_COUNT = "transport.jms.MaxConsumeErrorRetryCount";
     /**
      *The number of concurrent consumers to be created to poll for messages for this service
      * For Topics, this should be ONE, to prevent receipt of multiple copies of the same message

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -141,6 +141,11 @@ public class ServiceTaskManager {
      * Number of consume retries upon consume error.
      */
     private int consumerRetryCount = 0;
+    /**
+     * Maximum consumer retries on consume error: after this value is reached a manual Connection exception will be
+     * thrown.
+     */
+    private Integer maxConsumerErrorRetryCount = -1; // default is -1
     /** Upper limit on reconnection attempt duration */
     private long maxReconnectDuration = 1000 * 60 * 1; // 1 min
 	/** Reconnect duration in case of a failure */
@@ -491,7 +496,14 @@ public class ServiceTaskManager {
                                 Thread.currentThread().getId() + " for destination : " + destination);
                         }
                     }
-
+                    if (maxConsumerErrorRetryCount != -1 && consumerRetryCount > maxConsumerErrorRetryCount) {
+                        log.warn("Creating a Forced Error Recovery task for Connection level recovery "
+                                + "for the service : " + serviceName);
+                        ErrorRecoverTask errorRecoverTask = new ErrorRecoverTask(this);
+                        Thread errorRecoverThread = new Thread(errorRecoverTask);
+                        errorRecoverThread.setName("JMSForcedErrorRecoveryThread-" + errorRecoverThread.getId());
+                        errorRecoverThread.start();
+                    }
                     if (connectionReceivedError && (maxConsumeErrorRetryBeforeDelay < consumerRetryCount)) {
                         try {
                             Thread.sleep(retryDurationOnConsumerFailure);
@@ -1364,6 +1376,17 @@ public class ServiceTaskManager {
         }
     }
 
+    /**
+     * Method to set the maximum number of consumer retries when a consume error occurs.
+     *
+     * @param maxConsumerErrorRetryCount maximum number of consumer retries
+     */
+    public void setMaxConsumerErrorRetryCount(Integer maxConsumerErrorRetryCount) {
+        if (maxConsumerErrorRetryCount != null) {
+            this.maxConsumerErrorRetryCount = maxConsumerErrorRetryCount;
+        }
+    }
+
     public int getMaxMessagesPerTask() {
         return maxMessagesPerTask;
     }
@@ -1447,5 +1470,20 @@ public class ServiceTaskManager {
     
     public void setServiceTaskManagerState(int serviceTaskManagerState) {
         this.serviceTaskManagerState = serviceTaskManagerState;
+    }
+
+    /**
+     * Error recovery task to force recovery upon reaching {@link #maxConsumerErrorRetryCount}.
+     */
+    private static class ErrorRecoverTask implements Runnable {
+        private MessageListenerTask messageListenerTask;
+        public ErrorRecoverTask(MessageListenerTask messageListenerTask) {
+            this.messageListenerTask = messageListenerTask;
+        }
+        @Override
+        public void run() {
+            JMSException jmsException = new JMSException("FORCED CONNECTION RESTART", "FC_ERROR");
+            messageListenerTask.onException(jmsException);
+        }
     }
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
@@ -57,6 +57,8 @@ public class ServiceTaskManagerFactory {
                 JMSConstants.PARAM_CONSUME_ERROR_PROGRESSION, svc, cf));
         stm.setMaxConsumeErrorRetryBeforeDelay(getOptionalIntProperty(
                 JMSConstants.PARAM_MAX_CONSUME_RETRY_BEFORE_DELAY, svc, cf));
+        stm.setMaxConsumerErrorRetryCount(getOptionalIntProperty(
+                JMSConstants.PARAM_MAX_CONSUME_RETRY_COUNT, svc, cf));
 
         String destName = getOptionalStringProperty(JMSConstants.PARAM_DESTINATION, svc, cf);
         if (destName == null) {


### PR DESCRIPTION
## Purpose
> Introduce a fix for situations where the JMS Transport Consumer is unable to recover when the Exception Listener is not notified of exceptions. Resolves https://wso2.org/jira/browse/ESBJAVA-5128.

## Goals
> Introduce a task to notify the JMS Exception Listener in situations where the Exception Listener is not notified of exceptions.

## Approach
> Introduce a forced recovery task to notify the JMS Exception Listener, for situations where trying to consume results in an error, but the Exception Listener is not notified. Recovery will be forced once the number of retries reaches a pre-specified number. 

## User stories
> N/A

## Release note
> Fix for situations where the JMS Transport Consumer is unable to recover when the Exception Listener is not notified of exceptions.

## Documentation
> wso2/product-ei/issues/1110

## Training
> N/A

## Certification
> N/A - new parameter introduced to fix an intermittent issue.

## Automation tests
 - Fix is for an intermittent issue, and cannot be reproduced/tested.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes