### PR TITLE
Fix for issue ei#1127

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -456,6 +456,8 @@ public class ServiceTaskManager {
                 workerState = STATE_PAUSED;
             }
 
+            log.info("JMS Polling task activated with state: " + workerState + " for service " + serviceName);
+
             try {
                 while (isActive() &&
                     (getMaxMessagesPerTask() < 0 || messageCount < getMaxMessagesPerTask()) &&
@@ -519,10 +521,11 @@ public class ServiceTaskManager {
                         idleExecutionCount++;
                     }
                 }
-			} catch (AxisJMSException e) {
-				log.error("Error reciving the message.");
+            } catch (AxisJMSException e) {
+                log.error("Error receiving the message.");
             } finally {
-                
+                log.info("JMS Polling server task stopped for service " + serviceName +
+                        " Service state " + workerState);
                 if (log.isTraceEnabled()) {
                     log.trace("Listener task with Thread ID : " + Thread.currentThread().getId() +
                         " is stopping after processing : " + messageCount + " messages :: " +


### PR DESCRIPTION
Add additional logs for JMS service task.

## Purpose
This is to identify whether a specific JMS proxy service started and stopped.
Issue: https://github.com/wso2/product-ei/issues/1127

## Goals
> Add debug logs for the task

## User stories
> None

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> N/A - added additional debug logs

## Training
> Doesn't affect training content

## Certification
> Doesn't affect certificate questions since this is some debug logs

## Marketing
> Doesn't affect marketing content.

## Automation tests
 - Unit tests 
   > N/A this to identify probable issue not a bug fix
 - Integration tests
   > N/A this to identify probable issue not a bug fix
## Security checks
 -  yes/no
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Not a feature

## Related PRs
> None

## Migrations (if applicable)
> N/A

## Test environment
> Any JDK version, any OS
 
## Learning
> Found an issue with JMS task not consuming messages after a successful reconnect. This logs will be valuable to identify whether the task loop stopped executing after the reconnection.