### PR TITLE
 Fix for issue ei#1138

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -524,8 +524,7 @@ public class ServiceTaskManager {
             } catch (AxisJMSException e) {
                 log.error("Error receiving the message.");
             } finally {
-                log.info("JMS Polling server task stopped for service " + serviceName +
-                        " Service state " + workerState);
+                log.info("JMS Polling server task stopped for service " + serviceName + " " + this);
                 if (log.isTraceEnabled()) {
                     log.trace("Listener task with Thread ID : " + Thread.currentThread().getId() +
                         " is stopping after processing : " + messageCount + " messages :: " +
@@ -768,6 +767,7 @@ public class ServiceTaskManager {
                             Thread.sleep(retryDuration);
                             if (getConnectedTaskCount() == concurrentConsumers) {
                                 connected = true;
+                                isOnExceptionError = false;
                                 log.info("Reconnection attempt: " + r + " for service: " + serviceName +
                                         " was successful!");
                             }
@@ -1015,6 +1015,18 @@ public class ServiceTaskManager {
 				}
 				throw new AxisJMSException(msg, e);
             }
+        }
+
+        @Override
+        public String toString() {
+            return "MessageListenerTask{" +
+                    "workerState=" + workerState +
+                    ", idleExecutionCount=" + idleExecutionCount +
+                    ", idle=" + idle +
+                    ", connected=" + connected +
+                    ", listenerPaused=" + listenerPaused +
+                    ", connectionReceivedError=" + connectionReceivedError +
+                    '}';
         }
     }
 

--- a/modules/testkit/src/main/java/org/apache/axis2/transport/testkit/tests/misc/MinConcurrencyTest.java
+++ b/modules/testkit/src/main/java/org/apache/axis2/transport/testkit/tests/misc/MinConcurrencyTest.java
@@ -88,7 +88,9 @@ public class MinConcurrencyTest extends ManagedTestCase {
                     concurrencyReachedLock.notifyAll();
                 }
                 try {
-                    shutdownAwaitLock.wait();
+                    synchronized (shutdownAwaitLock) {
+                        shutdownAwaitLock.wait();
+                    }
                 } catch (InterruptedException ex) {
                 }
             }


### PR DESCRIPTION
## Purpose
> JMS proxy service after the idle task count is exceeded stops consuming messages and exits the message receiving loop. This is an intermittant issue

Issue: https://github.com/wso2/product-ei/issues/1138

## Goals
> Fixed by adding the missing update for the isOnExceptionError value when successfully connected to the broker.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Intermittently JMS proxy consumers getting stopped after exceeding max idle count

## Documentation
> Doesn't affect documentation.

## Automation tests
 - Unit tests 
   > Not added
 - Integration tests
   > Not added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> This is a bug fix. Doesn't affect the samples
