### PR TITLE
EI#1156: Fix for continuous creation of threads at listener pause state

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSListener.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSListener.java
@@ -244,10 +244,12 @@ public class JMSListener extends AbstractTransportListenerEx<JMSEndpoint> implem
     public void resume() throws AxisFault {
         if (state != BaseConstants.PAUSED) return;
         try {
+            state = BaseConstants.STARTED;
             for (JMSEndpoint endpoint : getEndpoints()) {
+                Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+                endpoint.getServiceTaskManager().scheduleNewTaskIfAppropriate();
                 endpoint.getServiceTaskManager().resume();
             }
-            state = BaseConstants.STARTED;
             log.info("Listener resumed");
         } catch (AxisJMSException e) {
             log.error("At least one service could not be resumed", e);

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -330,13 +330,10 @@ public class ServiceTaskManager {
      * Start a new MessageListenerTask if we are still active, the threshold is not reached, and w
      * e do not have any idle tasks - i.e. scale up listening
      */
-    private void scheduleNewTaskIfAppropriate() {
+    public void scheduleNewTaskIfAppropriate() {
         if (serviceTaskManagerState == STATE_STARTED &&
-            pollingTasks.size() < getMaxConcurrentConsumers() && getIdleTaskCount() == 0) {
-
-            if (jmsMessageReceiver.getJmsListener().getState() == BaseConstants.PAUSED) {
-                workerPool.execute(new MessageListenerTask(BaseConstants.PAUSED));
-            } else {
+                pollingTasks.size() < getMaxConcurrentConsumers() && getIdleTaskCount() == 0) {
+            if (jmsMessageReceiver.getJmsListener().getState() != BaseConstants.PAUSED) {
                 workerPool.execute(new MessageListenerTask(BaseConstants.STARTED));
             }
         }


### PR DESCRIPTION
## Purpose
Remove unnecessary thread creation at jms listener "pause" state.

## Goals
Fixed: https://github.com/wso2/product-ei/issues/1156

## Approach
Removed thread creation at pause state and created necessary threads at the listener resume.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A