### PR TITLE
Fix EI-1244 jms OOM issue

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -373,6 +373,11 @@ public class JMSConstants {
 
     public static final String JMS_XA_TRANSACTION_MANAGER = "distributedTxMgr";
 
+    /**
+    * Will be used identify transactionality.
+    */
+    public static final String JMS_TRANSACTION_COMMAND = "transport.jms.TransactionCommand";
+
     public static final String JMS_SPEC_VERSION_1_1 = "1.1";
 
     public static final String JMS_SPEC_VERSION_2_0 = "2.0";

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -58,7 +58,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
 
     public static final String TRANSPORT_NAME = Constants.TRANSPORT_JMS;
 
-    private static Map<Transaction, ArrayList<JMSMessageSender>> JMSMessageSenderMap = new HashMap<>();
+    private static Map<Transaction, ArrayList<JMSMessageSender>> jmsMessageSenderMap = new HashMap<>();
     /** The JMS connection factory manager to be used when sending messages out */
     private JMSConnectionFactoryManager connFacManager;
 
@@ -135,16 +135,19 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
             } else {
                 try {
                     messageSender = jmsOut.createJMSSender(msgCtx);
-                    Transaction transaction = (Transaction) msgCtx.getProperty(JMSConstants.JMS_XA_TRANSACTION);
-
-                    if (JMSMessageSenderMap.get(transaction) == null) {
-                        ArrayList list = new ArrayList();
-                        list.add(messageSender);
-                        JMSMessageSenderMap.put(transaction, list);
-                    } else {
-                        ArrayList list = JMSMessageSenderMap.get(transaction);
-                        list.add(messageSender);
-                        JMSMessageSenderMap.put(transaction, list);
+                    // MessageSender only needed to add if the scenario involved with XA transaction.
+                    // It can be identified by looking at target url's transport.jms.TransactionCommand parameter.
+                    if ((targetAddress.contains(JMSConstants.JMS_TRANSACTION_COMMAND))) {
+                        Transaction transaction = (Transaction) msgCtx.getProperty(JMSConstants.JMS_XA_TRANSACTION);
+                        if (jmsMessageSenderMap.get(transaction) == null) {
+                            ArrayList list = new ArrayList();
+                            list.add(messageSender);
+                            jmsMessageSenderMap.put(transaction, list);
+                        } else {
+                            ArrayList list = jmsMessageSenderMap.get(transaction);
+                            list.add(messageSender);
+                            jmsMessageSenderMap.put(transaction, list);
+                        }
                     }
 
                 } catch (JMSException e) {
@@ -635,7 +638,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
     }
 
     private void commitXATransaction(Transaction transaction) throws AxisFault {
-        ArrayList<JMSMessageSender> msgSenderList = (ArrayList) JMSMessageSenderMap.get(transaction);
+        ArrayList<JMSMessageSender> msgSenderList = (ArrayList) jmsMessageSenderMap.get(transaction);
         if (msgSenderList.size() > 0) {
             for (JMSMessageSender msgSender : msgSenderList) {
                 try {
@@ -649,12 +652,12 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
                 }
 
             }
-            JMSMessageSenderMap.remove(transaction);
+            jmsMessageSenderMap.remove(transaction);
         }
     }
 
     private void rollbackXATransaction(Transaction transaction) throws AxisFault {
-        ArrayList<JMSMessageSender> msgSenderList = (ArrayList) JMSMessageSenderMap.get(transaction);
+        ArrayList<JMSMessageSender> msgSenderList = (ArrayList) jmsMessageSenderMap.get(transaction);
         if (msgSenderList.size() > 0) {
             for (JMSMessageSender msgSender : msgSenderList) {
                 try {
@@ -667,7 +670,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
                     msgSender.closeOnException();
                 }
             }
-            JMSMessageSenderMap.remove(transaction);
+            jmsMessageSenderMap.remove(transaction);
         }
     }
 }


### PR DESCRIPTION
## Purpose
This fixes a possible OOM issue when publishing messages to a broker using jms
Related issue is: https://github.com/wso2/product-ei/issues/1244

## Goals
The issue happened the JMSMessageSenderMap is not getting cleared unless it is an XA transaction scenario. The fix is to add MessageSender to the map only if the scenario involved with XA transaction.