### PR TITLE
add unit test to verify fix for OOM

### DIFF
--- a/modules/jms/pom.xml
+++ b/modules/jms/pom.xml
@@ -154,9 +154,15 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--Mockito Dependency-->
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
+++ b/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
@@ -17,10 +17,37 @@ package org.apache.axis2.transport.jms;
 
 import junit.framework.Assert;
 import junit.framework.TestCase;
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.description.TransportOutDescription;
+import org.apache.axis2.engine.AxisConfiguration;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import javax.jms.Destination;
+import javax.jms.Session;
+import javax.transaction.HeuristicMixedException;
+import javax.transaction.HeuristicRollbackException;
+import javax.transaction.RollbackException;
+import javax.transaction.Synchronization;
+import javax.transaction.SystemException;
+import javax.transaction.Transaction;
+import javax.transaction.xa.XAResource;
 
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JMSSender.class)
+@PowerMockIgnore("javax.management.*")
 public class JMSSenderTestCase extends TestCase {
 
     private String assertErrorMessageForTrue = "waitForResponse is false and destination is null";
@@ -49,4 +76,87 @@ public class JMSSenderTestCase extends TestCase {
         Assert.assertFalse(assertErrorMessageForFalse, result);
     }
 
+    /**
+     * Test case for EI-1244.
+     * test transport.jms.TransactionCommand parameter in transport url when sending the message.
+     * This will verify the fixes which prevent possible OOM issue when publishing messages to a broker using jms.
+     *
+     * @throws Exception
+     */
+    public void testTransactionCommandParameter() throws Exception {
+        JMSSender jmsSender = PowerMockito.spy(new JMSSender());
+        JMSOutTransportInfo jmsOutTransportInfo = Mockito.mock(JMSOutTransportInfo.class);
+        JMSMessageSender jmsMessageSender = Mockito.mock(JMSMessageSender.class);
+        Session session = Mockito.mock(Session.class);
+
+        Mockito.doReturn(session).when(jmsMessageSender).getSession();
+        PowerMockito.whenNew(JMSOutTransportInfo.class).withArguments(any(String.class))
+                .thenReturn(jmsOutTransportInfo);
+        Mockito.doReturn(jmsMessageSender).when(jmsOutTransportInfo).createJMSSender(any(MessageContext.class));
+        PowerMockito.doNothing()
+                .when(jmsSender, "sendOverJMS", ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
+                        ArgumentMatchers.any(), ArgumentMatchers.any());
+
+        jmsSender.init(new ConfigurationContext(new AxisConfiguration()), new TransportOutDescription("jms"));
+        MessageContext messageContext = new MessageContext();
+        //append the transport.jms.TransactionCommand
+        String targetAddress = "jms:/SimpleStockQuoteService?transport.jms.ConnectionFactoryJNDIName="
+                + "QueueConnectionFactory&transport.jms.TransactionCommand=begin"
+                + "&java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory";
+        Transaction transaction = new TestJMSTransaction();
+        messageContext.setProperty(JMSConstants.JMS_XA_TRANSACTION, transaction);
+
+        jmsSender.sendMessage(messageContext, targetAddress, null);
+        Map<Transaction, ArrayList<JMSMessageSender>> jmsMessageSenderMap = Whitebox
+                .getInternalState(JMSSender.class, "jmsMessageSenderMap");
+        Assert.assertEquals("Transaction not added to map", 1, jmsMessageSenderMap.size());
+        List senderList = jmsMessageSenderMap.get(transaction);
+        Assert.assertNotNull("List is null", senderList );
+        Assert.assertEquals("List is empty", 1, senderList.size());
+    }
+
+    /**
+     * Test class which implement javax.Transaction for test transport.jms.TransactionCommand.
+     */
+    private class TestJMSTransaction implements Transaction {
+
+        @Override
+        public void commit()
+                throws HeuristicMixedException, HeuristicRollbackException, RollbackException, SecurityException,
+                SystemException {
+
+        }
+
+        @Override
+        public boolean delistResource(XAResource xaResource, int i) throws IllegalStateException, SystemException {
+            return false;
+        }
+
+        @Override
+        public boolean enlistResource(XAResource xaResource)
+                throws IllegalStateException, RollbackException, SystemException {
+            return false;
+        }
+
+        @Override
+        public int getStatus() throws SystemException {
+            return 0;
+        }
+
+        @Override
+        public void registerSynchronization(Synchronization synchronization)
+                throws IllegalStateException, RollbackException, SystemException {
+
+        }
+
+        @Override
+        public void rollback() throws IllegalStateException, SystemException {
+
+        }
+
+        @Override
+        public void setRollbackOnly() throws IllegalStateException, SystemException {
+
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>3.8.2</version>
+                <version>${junit.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.aspectj</groupId>
@@ -323,10 +323,17 @@
                 <artifactId>xmlunit</artifactId>
                 <version>1.2</version>
             </dependency>
+            <!--Mockito Dependency-->
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>${mockito.version}</version>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito2</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -594,6 +601,8 @@
         <slf4j-version>1.4.3</slf4j-version>
         <paho.version>1.0.2</paho.version>
         <mockito.version>1.9.5</mockito.version>
+        <powermock.version>1.7.1</powermock.version>
+        <junit.version>4.8.2</junit.version>
     </properties>
 
 </project>


### PR DESCRIPTION
## Purpose
> This unit test will verify the fix done to prevent the OOM issue reported in git issue EI-1244.
This will verify when and only the transport.jms.TransactionCommand is present in jms url, transaction is added to the map.

## Related PRs
>https://github.com/wso2/wso2-axis2-transports/pull/132
