### PR TITLE
Fix wso2/product-ei#1294

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactoryManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactoryManager.java
@@ -38,6 +38,35 @@ public class JMSConnectionFactoryManager {
         new HashMap<String,JMSConnectionFactory>();
 
     /**
+     * Construct a Connection factory manager for the JMS transport sender or receiver
+     *
+     * @param trpInDesc the transport description for JMS
+     */
+    @Deprecated
+    public JMSConnectionFactoryManager(ParameterInclude trpInDesc) {
+        loadConnectionFactoryDefinitions(trpInDesc);
+    }
+
+    /**
+     * Create JMSConnectionFactory instances for the definitions in the transport configuration,
+     * and add these into our collection of connectionFactories map keyed by name
+     *
+     * @param trpDesc the transport description for JMS
+     */
+    @Deprecated
+    private void loadConnectionFactoryDefinitions(ParameterInclude trpDesc) {
+
+        for (Parameter p : trpDesc.getParameters()) {
+            try {
+                JMSConnectionFactory jmsConFactory = new JMSConnectionFactory(p);
+                connectionFactories.put(jmsConFactory.getName(), jmsConFactory);
+            } catch (AxisJMSException e) {
+                log.error("Error setting up connection factory : " + p.getName(), e);
+            }
+        }
+    }
+
+    /**
      * Construct a Connection factory manager for the JMS transport sender or receiver.
      *
      * @param trpInDesc the transport description for JMS

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
@@ -71,6 +71,30 @@ public class RabbitMQConnectionFactory {
     private Address[] addresses;
 
     /**
+     * Digest a AMQP CF definition from an axis2.xml 'Parameter' and construct.
+     *
+     * @param parameter the axis2.xml 'Parameter' that defined the AMQP CF
+     */
+    @Deprecated
+    public RabbitMQConnectionFactory(Parameter parameter) {
+        this.name = parameter.getName();
+        ParameterIncludeImpl pi = new ParameterIncludeImpl();
+
+        try {
+            pi.deserializeParameters((OMElement) parameter.getValue());
+        } catch (AxisFault axisFault) {
+            handleException("Error reading parameters for RabbitMQ connection factory" + name, axisFault);
+        }
+
+        for (Object o : pi.getParameters()) {
+            Parameter p = (Parameter) o;
+            parameters.put(p.getName(), (String) p.getValue());
+        }
+        initConnectionFactory();
+        log.info("RabbitMQ ConnectionFactory : " + name + " initialized");
+    }
+
+    /**
      * Digest a AMQP CF definition from an axis2.xml 'Parameter' and construct
      *
      * @param parameter the axis2.xml 'Parameter' that defined the AMQP CF

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactoryManager.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactoryManager.java
@@ -36,6 +36,16 @@ public class RabbitMQConnectionFactoryManager {
             new HashMap<String, RabbitMQConnectionFactory>();
 
     /**
+     * Construct a Connection factory manager for the RabbitMQ transport sender or receiver.
+     *
+     * @param description the transport description for RabbitMQ
+     */
+    @Deprecated
+    public RabbitMQConnectionFactoryManager(ParameterInclude description) {
+        loadConnectionFactoryDefinitions(description);
+    }
+
+    /**
      * Construct a Connection factory manager for the RabbitMQ transport sender or receiver
      *
      * @param description
@@ -108,6 +118,20 @@ public class RabbitMQConnectionFactoryManager {
      */
     public RabbitMQConnectionFactory getConnectionFactory(String connectionFactoryName) {
         return connectionFactories.get(connectionFactoryName);
+    }
+
+    /**
+     * Create ConnectionFactory instances for the definitions in the transport configuration,
+     * and add these into our collection of connectionFactories map keyed by name.
+     *
+     * @param trpDesc the transport description for RabbitMQ AMQP
+     */
+    @Deprecated
+    private void loadConnectionFactoryDefinitions(ParameterInclude trpDesc) {
+        for (Parameter parameter : trpDesc.getParameters()) {
+            RabbitMQConnectionFactory amqpConFactory = new RabbitMQConnectionFactory(parameter);
+            connectionFactories.put(amqpConFactory.getName(), amqpConFactory);
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Maintain the APIs with the fixes for JMS and RabbitMQ transport parameter decryption. Resolves wso2/product-ei#1294.

## Goals
> Mark original constructors as deprecated with the introduction of the new constructors.

## Approach
>  Reintroduce original constructors deprecated with the introduction of the fixes for JMS and RabbitMQ transport parameter decryption, with PR #126 and PR #111, and mark them as deprecated.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
> #126, #111