### PR TITLE
Fix Unable to set JMS_DELIVERY_MODE property

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -254,6 +254,14 @@ public class JMSConstants {
      * Value 2 - javax.jms.DeliveryMode.PERSISTENT
      */
     public static final String JMS_DELIVERY_MODE = "JMS_DELIVERY_MODE";
+
+    /**
+     * Acceptable String values (PERSISTENT and NON_PERSISTENT) for JMS_DELIVERY_MODE in axis2 scope
+     */
+    public static final String JMS_PERSISTENT_DELIVERY_MODE = "PERSISTENT";
+    public static final String JMS_NON_PERSISTENT_DELIVERY_MODE = "NON_PERSISTENT";
+
+
     /**
      * A MessageContext property or client Option indicating the JMS destination to use on a Send
      */


### PR DESCRIPTION
## Purpose
> Regardless of the deliveryMode property that can be declared from client-end, it will always be set to persistent by default. Need to update it to set to persistent/non-persistent depending on the value of JMS_DELIVERY_MODE property

## Goals
> JMS_DELIVERY_MODE property become effective for producers

## Approach
> This fix accept a string with following values "PERSISTENT" or "NON_PERSISTENT" for JMS_DELIVERY_MODE property in axis2 scope

## Documentation
> The JMS_DELIVERY_MODE property is used in two ways in two places based on the sope:
> **Transport scope**
> ```<property name="JMS_DELIVERY_MODE" scope="transport" value="1"/>```
> When we define in transport scope, JMSDeliveryMode is effective per message. And expect integer or string. "1" for DeliveryMode.NON_PERSISTENT and "2" DeliveryMode.PERSISTENT.

> **Axis2 scope**
> ```<property name="JMS_DELIVERY_MODE" scope="axis2" value="NON_PERSISTENT"/>```
> When we define in axis2 scope, JMSDeliveryMode is effective per producer. JMS_DELIVERY_MODE will accept a string with following values "PERSISTENT" or "NON_PERSISTENT"
  