### PR TITLE
Jacoco plugin integration for unit tests coverage

### DIFF
--- a/modules/jms/pom.xml
+++ b/modules/jms/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~  Licensed to the Apache Software Foundation (ASF) under one
   ~  or more contributor license agreements.  See the NOTICE file
   ~  distributed with this work for additional information
@@ -16,9 +15,7 @@
   ~  KIND, either express or implied.  See the License for the
   ~  specific language governing permissions and limitations
   ~  under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.axis2.transport</groupId>
@@ -26,18 +23,15 @@
         <version>2.0.0-wso2v18-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>axis2-transport-jms</artifactId>
     <name>Apache Axis2 - Transport - JMS</name>
     <description>Apache Axis2 - JMS Transport</description>
     <packaging>bundle</packaging>
-
     <!--scm>
         <connection>scm:svn:http://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/jms</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/jms</developerConnection>
         <url>http://svn.apache.org/viewvc/axis/axis2/java/transports/trunk/modules/jms</url>
     </scm-->
-
     <build>
         <plugins>
             <plugin>
@@ -74,6 +68,7 @@
                         </property>
                     </systemProperties>
                     <argLine>-javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
+                    <argLine>${argLine}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -98,15 +93,17 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-base</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.axis2.transport</groupId>
             <artifactId>axis2-transport-testkit</artifactId>
@@ -166,7 +163,6 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
     <repositories>
         <!-- this is for qpid -->
         <repository>
@@ -181,8 +177,5 @@
             </snapshots>
         </repository>
     </repositories>
-
-    <properties>
-    </properties>
-
+    <properties/>
 </project>

--- a/modules/mail/pom.xml
+++ b/modules/mail/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~  Licensed to the Apache Software Foundation (ASF) under one
   ~  or more contributor license agreements.  See the NOTICE file
   ~  distributed with this work for additional information
@@ -16,9 +15,7 @@
   ~  KIND, either express or implied.  See the License for the
   ~  specific language governing permissions and limitations
   ~  under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.axis2.transport</groupId>
@@ -26,18 +23,15 @@
         <version>2.0.0-wso2v18-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>axis2-transport-mail</artifactId>
     <name>Apache Axis2 - Transport - Mail</name>
     <description>Apache Axis2 - Mail Transport</description>
     <packaging>bundle</packaging>
-
     <!--scm>
       <connection>scm:svn:http://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/mail</connection>
       <developerConnection>scm:svn:https://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/mail</developerConnection>
       <url>http://svn.apache.org/viewvc/axis/axis2/java/transports/trunk/modules/mail</url>
     </scm-->
-
     <build>
         <plugins>
             <plugin>
@@ -99,17 +93,20 @@
                         </property>
                     </systemProperties>
                     <argLine>-javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
+                    <argLine>${argLine}</argLine>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>javax.mail</groupId>
             <artifactId>mail</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-base</artifactId>
@@ -120,7 +117,6 @@
                     <artifactId>geronimo-javamail_1.4_spec</artifactId>
                 </exclusion>
             </exclusions>
-
         </dependency>
         <dependency>
             <groupId>org.apache.axis2.transport</groupId>

--- a/modules/sms/pom.xml
+++ b/modules/sms/pom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~  Licensed to the Apache Software Foundation (ASF) under one
   ~  or more contributor license agreements.  See the NOTICE file
   ~  distributed with this work for additional information
@@ -16,9 +15,7 @@
   ~  KIND, either express or implied.  See the License for the
   ~  specific language governing permissions and limitations
   ~  under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.axis2.transport</groupId>
@@ -26,18 +23,15 @@
         <version>2.0.0-wso2v18-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>axis2-transport-sms</artifactId>
     <name>Apache Axis2 - Transport - Sms</name>
     <description>Apache Axis2 - SmsTransport</description>
     <packaging>bundle</packaging>
-
     <!--scm>
         <connection>scm:svn:http://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/sms</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/sms</developerConnection>
         <url>http://svn.apache.org/viewvc/axis/axis2/java/transports/trunk/modules/sms</url>
     </scm-->
-
     <build>
         <plugins>
             <plugin>
@@ -99,9 +93,9 @@
                         </property>
                     </systemProperties>
                     <argLine>-javaagent:target/lib/aspectjweaver.jar -Xms64m -Xmx128m</argLine>
+                    <argLine>${argLine}</argLine>
                 </configuration>
             </plugin>
-
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -111,16 +105,16 @@
                         <phase>test-compile</phase>
                         <configuration>
                             <tasks unless="maven.test.skip">
-                                <mkdir dir="target/test-resources/samples/conf" />
-                                <mkdir dir="target/test-resources/samples/repository/modules" />
-                                <mkdir dir="target/test-resources/samples/repository/services" />
-                                <mkdir dir="target/test-resources/samples/repository/services/SampleService/org/apache/axis2/transport/sms" />
-                                <mkdir dir="target/test-resources/samples/repository/services/SampleService/META-INF" />
-                                <copy file="${settings.localRepository}/org/apache/axis2/addressing/${axis2.version}/addressing-${axis2.version}.mar" tofile="target/test-resources/samples/repository/modules/addressing.mar" />
-                                <copy file="target/test-classes/org/apache/axis2/transport/sms/SimpleInOutMessageReceiver.class" tofile="target/test-resources/samples/repository/services/SampleService/org/apache/axis2/transport/sms/SimpleInOutMessageReceiver.class" />
-                                <copy file="conf/axis2.xml" tofile="target/test-resources/samples/conf/axis2.xml" />
-                                <copy file="repository/services/SampleService/META-INF/MANIFEST.MF" tofile="target/test-resources/samples/repository/services/SampleService/META-INF/MANIFEST.MF" />
-                                <copy file="repository/services/SampleService/META-INF/services.xml" tofile="target/test-resources/samples/repository/services/SampleService/META-INF/services.xml" />
+                                <mkdir dir="target/test-resources/samples/conf"/>
+                                <mkdir dir="target/test-resources/samples/repository/modules"/>
+                                <mkdir dir="target/test-resources/samples/repository/services"/>
+                                <mkdir dir="target/test-resources/samples/repository/services/SampleService/org/apache/axis2/transport/sms"/>
+                                <mkdir dir="target/test-resources/samples/repository/services/SampleService/META-INF"/>
+                                <copy file="${settings.localRepository}/org/apache/axis2/addressing/${axis2.version}/addressing-${axis2.version}.mar" tofile="target/test-resources/samples/repository/modules/addressing.mar"/>
+                                <copy file="target/test-classes/org/apache/axis2/transport/sms/SimpleInOutMessageReceiver.class" tofile="target/test-resources/samples/repository/services/SampleService/org/apache/axis2/transport/sms/SimpleInOutMessageReceiver.class"/>
+                                <copy file="conf/axis2.xml" tofile="target/test-resources/samples/conf/axis2.xml"/>
+                                <copy file="repository/services/SampleService/META-INF/MANIFEST.MF" tofile="target/test-resources/samples/repository/services/SampleService/META-INF/MANIFEST.MF"/>
+                                <copy file="repository/services/SampleService/META-INF/services.xml" tofile="target/test-resources/samples/repository/services/SampleService/META-INF/services.xml"/>
                             </tasks>
                         </configuration>
                         <goals>
@@ -129,9 +123,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
-
     <repositories>
         <repository>
             <id>apache-snapshots</id>
@@ -158,7 +155,6 @@
             </snapshots>
         </repository>
     </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.axis2</groupId>
@@ -193,8 +189,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
-    <properties>
-    </properties>
+    <properties/>
 </project>

--- a/modules/udp/pom.xml
+++ b/modules/udp/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements. See the NOTICE file
   ~ distributed with this work for additional information
@@ -17,9 +15,7 @@
   ~ KIND, either express or implied. See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.axis2.transport</groupId>
@@ -27,18 +23,15 @@
         <version>2.0.0-wso2v18-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
-
     <artifactId>axis2-transport-udp</artifactId>
     <name>Apache Axis2 - Transport - UDP</name>
     <description>UDP transport for Axis2</description>
     <packaging>bundle</packaging>
-
     <!--scm>
         <connection>scm:svn:http://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/udp</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/axis/axis2/java/transports/trunk/modules/udp</developerConnection>
         <url>http://svn.apache.org/viewvc/axis/axis2/java/transports/trunk/modules/udp</url>
     </scm-->
-
     <build>
         <plugins>
             <plugin>
@@ -57,9 +50,19 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${argLine}</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.axis2</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<!--
+<?xml version="1.0" encoding="UTF-8"?><!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements. See the NOTICE file
   ~ distributed with this work for additional information
@@ -17,9 +15,7 @@
   ~ KIND, either express or implied. See the License for the
   ~ specific language governing permissions and limitations
   ~ under the License.
-  -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  --><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.wso2</groupId>
@@ -33,14 +29,12 @@
     <name>Apache Axis2 Transport</name>
     <inceptionYear>2004</inceptionYear>
     <url>http://axis.apache.org/axis2/java/core/</url>
-
     <scm>
         <connection>scm:git:https://github.com/wso2/wso2-axis2-transports.git</connection>
         <developerConnection>scm:git:https://github.com/wso2/wso2-axis2-transports.git</developerConnection>
         <url>https://github.com/wso2/wso2-axis2-transports.git</url>
         <tag>HEAD</tag>
     </scm>
-
     <profiles>
         <profile>
             <id>default</id>
@@ -63,7 +57,6 @@
                 <module>modules/sms</module>
                 <module>modules/msmq</module>
                 <module>modules/testkit</module>
-
                 <module>features/org.apache.axis2.transport.jms.feature</module>
                 <module>features/org.apache.axis2.transport.mail.feature</module>
                 <module>features/org.apache.axis2.transport.tcp.feature</module>
@@ -96,8 +89,6 @@
             </modules>
         </profile>
     </profiles>
-
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -110,7 +101,6 @@
                 <artifactId>org.wso2.carbon.core.common</artifactId>
                 <version>${carbon.kernel.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>org.apache.axis2.transport</groupId>
                 <artifactId>axis2-transport-jms</artifactId>
@@ -161,7 +151,6 @@
                 <artifactId>axis2-transport-sms</artifactId>
                 <version>${axis2.transports.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>servlet-api</artifactId>
@@ -237,7 +226,6 @@
                 <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
                 <version>${paho.version}</version>
             </dependency>
-
             <!-- Smack Jabber client libraries to be included -->
             <dependency>
                 <groupId>jivesoftware</groupId>
@@ -301,8 +289,6 @@
                 <artifactId>jetty</artifactId>
                 <version>5.1.10</version>
             </dependency>
-
-
             <!-- Dependencies used in the unit tests -->
             <dependency>
                 <groupId>junit</groupId>
@@ -344,14 +330,12 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-kernel</artifactId>
         </dependency>
     </dependencies>
-
     <repositories>
         <repository>
             <id>wso2-maven2-repository</id>
@@ -409,7 +393,6 @@
             </releases>
         </repository>
     </repositories>
-
     <pluginRepositories>
         <pluginRepository>
             <id>snapshot</id>
@@ -472,27 +455,23 @@
             </releases>
         </pluginRepository>
     </pluginRepositories>
-
     <distributionManagement>
         <!--repository>
             <id>wso2-maven2-repository</id>
             <name>WSO2 Maven2 Repository</name>
             <url>scp://dist.wso2.org/home/httpd/dist.wso2.org/maven2/</url>
         </repository-->
-
         <repository>
             <id>nexus-releases</id>
             <name>WSO2 Release Distribution Repository</name>
             <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
         </repository>
-
         <snapshotRepository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
             <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
-
     <build>
         <extensions>
             <extension>
@@ -572,11 +551,58 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-deploy-plugin</artifactId>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                            <configuration>
+                                <propertyName>argLine</propertyName>
+                                <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-report-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-check-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                                <rules>
+                                    <!-- implementation is needed only for Maven 2 -->
+                                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                        <element>BUNDLE</element>
+                                        <limits>
+                                            <!-- implementation is needed only for Maven 2 -->
+                                            <limit implementation="org.jacoco.report.check.Limit">
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.0</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
-
     </build>
-
     <properties>
         <axis2.transports.version>2.0.0-wso2v18-SNAPSHOT</axis2.transports.version>
         <axis2.version>1.6.1-wso2v23</axis2.version>
@@ -605,5 +631,4 @@
         <powermock.version>1.7.1</powermock.version>
         <junit.version>4.8.2</junit.version>
     </properties>
-
 </project>


### PR DESCRIPTION
## Purpose
Generate unit test coverage information

## Goals
Integrate Jacoco Maven plugin with Maven Surefire plugin to generate unit test coverage information 

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A

## Learning
N/A