### PR TITLE
Fixing wso2/wso2-axis2-transports#156 and wso2/wso2-axis2-transports#157

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
@@ -563,6 +563,15 @@ public class JMSConnectionFactory {
      * Clear the shared connection map due to stale connections
      */
     private synchronized void clearSharedConnections() {
+        for (Map.Entry<Integer, Connection> connectionMap : sharedConnectionMap.entrySet()) {
+            try {
+                if (connectionMap.getValue() != null) {
+                    connectionMap.getValue().close();
+                }
+            } catch (JMSException e) {
+                log.warn("Error while shutting down the connection : ", e);
+            }
+        }
         sharedConnectionMap.clear();
         lastReturnedConnectionIndex = 0;
     }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -176,6 +176,10 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         if (contentTypeProperty == null) {
             contentTypeProperty = jmsOut.getContentTypeProperty();
         }
+        
+        if (contentTypeProperty == null && jmsConnectionFactory != null) {
+            contentTypeProperty = jmsConnectionFactory.getParameters().get(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
+        }
 
         // Fix for ESBJAVA-3687, retrieve JMS transport property transport.jms.MessagePropertyHyphens and set this
         // into the msgCtx

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -169,17 +169,9 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         // The message property to be used to send the content type is determined by
         // the out transport info, i.e. either from the EPR if we are sending a request,
         // or, if we are sending a response, from the configuration of the service that
-        // received the request). The property name can be overridden by a message
-        // context property.
-        String contentTypeProperty =
-            (String) msgCtx.getProperty(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
-        if (contentTypeProperty == null) {
-            contentTypeProperty = jmsOut.getContentTypeProperty();
-        }
-        
-        if (contentTypeProperty == null && jmsConnectionFactory != null) {
-            contentTypeProperty = jmsConnectionFactory.getParameters().get(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
-        }
+        // received the request). The property can be defined globally in axis2.xml JMSSender section as well. 
+        // The property name can be overridden by a message context property.
+        String contentTypeProperty = getContentTypeProperty(msgCtx, jmsOut, jmsConnectionFactory);
 
         // Fix for ESBJAVA-3687, retrieve JMS transport property transport.jms.MessagePropertyHyphens and set this
         // into the msgCtx
@@ -232,6 +224,29 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         } catch (SystemException e1) {
             handleException("Error occurred during obtaining  transaction", e1);
         }
+    }
+
+    /**
+     * Retrieves the contentType property looking at the message context, jms outbound transport information 
+     * and connection factory parameters
+     * 
+     * @param msgCtx current message context
+     * @param jmsOut JMS outbound transport information 
+     * @param jmsConnectionFactory JMS connection factory
+     * @return the content type property name
+     */
+    protected String getContentTypeProperty(MessageContext msgCtx, JMSOutTransportInfo jmsOut,
+            JMSConnectionFactory jmsConnectionFactory) {
+
+        String contentTypeProperty =
+                (String) msgCtx.getProperty(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
+        if (contentTypeProperty == null) {
+            contentTypeProperty = jmsOut.getContentTypeProperty();
+        }
+        if (contentTypeProperty == null && jmsConnectionFactory != null) {
+            contentTypeProperty = jmsConnectionFactory.getParameters().get(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM);
+        }
+        return contentTypeProperty;
     }
 
     /**

--- a/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
+++ b/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
@@ -31,6 +31,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import javax.jms.Destination;
@@ -114,6 +115,22 @@ public class JMSSenderTestCase extends TestCase {
         List senderList = jmsMessageSenderMap.get(transaction);
         Assert.assertNotNull("List is null", senderList );
         Assert.assertEquals("List is empty", 1, senderList.size());
+    }
+
+    public void testGetContentTypePropertyNameFromFactory() {
+        final String contentTypeProperty = "contentType";
+        JMSSender jmsSender = new JMSSender();
+        MessageContext ctx = new MessageContext();
+
+        //setting up factory with content type property
+        JMSConnectionFactory factory = Mockito.mock(JMSConnectionFactory.class);
+        Hashtable<String, String> paramTable = new Hashtable<>();
+        paramTable.put(JMSConstants.CONTENT_TYPE_PROPERTY_PARAM, contentTypeProperty);
+        Mockito.when(factory.getParameters()).thenReturn(paramTable);
+
+        JMSOutTransportInfo jmsOutTransportInfo = new JMSOutTransportInfo(factory, null, null);
+        String contentTypePropertyResult = jmsSender.getContentTypeProperty(ctx, jmsOutTransportInfo, factory);
+        Assert.assertEquals(contentTypeProperty, contentTypePropertyResult);
     }
 
     /**


### PR DESCRIPTION
## Purpose
- Support ContentTypeProperty from axis2.xml
- Properly closing the connections in the pool when there are issues with any connection

## Documentation
ContentType property can be added as below to axis2.xml JMSSender proeprties.

`<parameter name="transport.jms.ContentTypeProperty">contentType</parameter>
`

Eg:

```
    <transportSender name="jms" class="org.apache.axis2.transport.jms.JMSSender">
		<parameter locked="false" name="eng-ESBSmallQueueSender">
			<parameter locked="false" name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
			<parameter locked="false" name="java.naming.provider.url">tcp://localhost:61616</parameter>
			<parameter locked="false" name="transport.jms.ConnectionFactoryJNDIName">QueueConnectionFactory</parameter>
			<parameter locked="false" name="transport.jms.ConnectionFactoryType">queue</parameter>
			<parameter locked="false" name="transport.jms.DestinationType">queue</parameter>
			<parameter locked="false" name="transport.jms.DefaultReplyDestinationType">queue</parameter>
            <parameter name="transport.jms.ContentTypeProperty">contentType</parameter>
		</parameter>
    </transportSender>

```
