### PR TITLE
Update RabbitMQMessageReceiver.java

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
@@ -21,6 +21,7 @@ package org.apache.axis2.transport.rabbitmq;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
 import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.rabbitmq.utils.RabbitMQConstants;
 import org.apache.axis2.transport.rabbitmq.utils.RabbitMQUtils;
 import org.apache.commons.logging.Log;

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
@@ -114,6 +114,14 @@ public class RabbitMQMessageReceiver {
                     RabbitMQUtils.getTransportHeaders(message),
                     soapAction,
                     contentType);
+            Object o = msgContext.getProperty(BaseConstants.SET_ROLLBACK_ONLY);
+            if (o != null) {
+                if ((o instanceof Boolean && ((Boolean) o)) ||
+                        (o instanceof String && Boolean.valueOf((String) o))) {
+                            return false;
+                }
+            }
+            
         } catch (AxisFault axisFault) {
             log.error("Error when trying to read incoming message ...", axisFault);
             return false;


### PR DESCRIPTION
Don't send ack in the only case of the variable SET_ROLLBACK_ONLY is exist

## Purpose
The current code always removes the message from RABBITMQ, even if the SET_ROLLBACK_ONLY variable exists.

## Goals
This fix don't remove the message of RabbitMQ in the only case the variable SET_ROLLBACK_ONLY exists.

##Issue
Related open Issue #166