### PR TITLE
Fix wso2/product-ei/issues/2182

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -137,6 +137,15 @@ public class JMSMessageSender {
      * @param msgCtx the Axis2 MessageContext
      */
     public void send(Message message, MessageContext msgCtx) {
+        // When we send a message to the reply queue, we need to remove the replyTo parameter from the message.
+        // Since the parameter is already used and no longer needed.
+        try {
+            if (message.getJMSReplyTo() == this.destination) {
+                message.setJMSReplyTo(null);
+            }
+        } catch (JMSException e) {
+            handleException("Error getting ReplyTo queue from message", e);
+        }
 
         Boolean jtaCommit    = getBooleanProperty(msgCtx, BaseConstants.JTA_COMMIT_AFTER_SEND);
         Boolean rollbackOnly = getBooleanProperty(msgCtx, BaseConstants.SET_ROLLBACK_ONLY);


### PR DESCRIPTION
## Purpose
> Remove replyTo parameter from message when we are replying to the same
queue.

## Goals
> When ESB sending a message to replyTo queue of previous message, new message should not contain anything in replyTo parameter. 

## Approach
> Set replyTo to null if destination and replyTo are the same

## Test environment
> JDK 8, IBM MQ 9 