### PR TITLE
Fix wso2/product-ei/issues/2182

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -452,4 +452,8 @@ public class JMSMessageSender {
     public void setJmsTransaction(Transaction jmsTransaction) {
         this.jmsTransaction = jmsTransaction;
     }
+
+    public Destination getDestination() {
+        return destination;
+    }
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -314,8 +314,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
                     tempDestination = messageSender.getSession().createTopic(replyDestName);
                 }
                 replyDestination = tempDestination;
-                message.setJMSReplyTo(tempDestination);
-
+                JMSUtils.setReplyDestination(replyDestination, messageSender.getDestination(), message);
             } catch (JMSException e) {
                 rollbackIfXATransaction(msgCtx);
                 handleException("Error setting the JMSReplyTo Header", e);

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
@@ -299,6 +299,26 @@ public class JMSUtils extends BaseUtils {
     }
 
     /**
+     * Set ReplyTo parameter of the message, only if we are not sending the message to the same destination.
+     *
+     * @param replyDestination   ReplyTo destination for the message.
+     * @param sendingDestination Actual destination of JMS message.
+     * @param message            JMS message.
+     */
+    public static void setReplyDestination(Destination replyDestination, Destination sendingDestination,
+                                           Message message) {
+        if (replyDestination != sendingDestination) {
+            try {
+                message.setJMSReplyTo(replyDestination);
+            } catch (JMSException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error when setting replyTo destination of the message", e);
+                }
+            }
+        }
+    }
+
+    /**
      * Set transport headers from the axis message context, into the JMS message
      *
      * @param msgContext the axis message context


### PR DESCRIPTION
## Purpose
> Remove replyTo parameter from message when we are replying to the same
queue.

## Goals
> When ESB sending a message to replyTo queue of previous message, new message should not contain anything in replyTo parameter. 

## Approach
> Set replyTo to null if destination and replyTo are the same

## Test environment
> JDK 8, IBM MQ 9 