### PR TITLE
FIX EI-2207-JMS Producer Caching

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
@@ -507,11 +507,29 @@ public class JMSConnectionFactory {
     public MessageProducer getMessageProducer(
         Connection connection, Session session, Destination destination) {
         if (cacheLevel > JMSConstants.CACHE_SESSION) {
-            return getSharedProducer();
+            return getNullDestinationSharedProducer();
         } else {
             return createProducer((session == null ? getSession(connection) : session), destination);
         }
     }
+
+    /**
+     * Get a shared MessageProducer from this JMS CF with destination set to null to use with multiple destinations
+     * when producer caching is enabled.
+     *
+     * @return shared MessageProducer from this JMS CF with destination set to null
+     */
+    private synchronized MessageProducer getNullDestinationSharedProducer() {
+        if (sharedProducer == null) {
+            sharedProducer = createProducer(getSharedSession(), null);
+            if (log.isDebugEnabled()) {
+                log.debug("Created shared JMS MessageConsumer with no destination specified, for JMS CF : " + name +
+                        " , with producer caching enabled");
+            }
+        }
+        return sharedProducer;
+    }
+
 
     /**
      * Get a new Connection or shared Connection from this JMS CF

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -53,6 +53,14 @@ public class JMSMessageSender {
     /** Are we sending to a Queue ? */
     private Boolean isQueue = null;
 
+    /**
+     +     * Boolean to track if producer caching will be honoured.
+     +     * True if producer caching is enabled and this {@link JMSMessageSender} is created specifying a
+     +     * {@link JMSConnectionFactory} and target EPR, via
+     +     * {@link JMSMessageSender#JMSMessageSender(JMSConnectionFactory, String)}.
+     +     */
+    private Boolean isProducerCachingHonoured = false;
+
     private Xid jmsXAXid;
     private XAResource jmsXaResource;
     private Transaction jmsTransaction;
@@ -115,15 +123,19 @@ public class JMSMessageSender {
 
         try {
             this.cacheLevel = jmsConnectionFactory.getCacheLevel();
+            this.isProducerCachingHonoured = cacheLevel > JMSConstants.CACHE_SESSION;
             this.jmsSpecVersion = jmsConnectionFactory.jmsSpecVersion();
             this.connection = jmsConnectionFactory.getConnection();
             this.session = jmsConnectionFactory.getSession(connection);
             boolean isQueue = jmsConnectionFactory.isQueue() == null ? true : jmsConnectionFactory.isQueue();
-            this.destination =
-                    jmsConnectionFactory.getSharedDestination() == null ?
-                            jmsConnectionFactory.getDestination(JMSUtils.getDestination(targetAddress),
-                                    isQueue ? JMSConstants.DESTINATION_TYPE_QUEUE : JMSConstants.DESTINATION_TYPE_TOPIC) :
-                            jmsConnectionFactory.getSharedDestination();
+            String destinationFromAddress = JMSUtils.getDestination(targetAddress);
+            //precedence is given to the destination specified by targetAddress
+            if(destinationFromAddress != null && !destinationFromAddress.isEmpty()) {
+                this.destination = jmsConnectionFactory.getDestination(JMSUtils.getDestination(targetAddress),
+                        isQueue ? JMSConstants.DESTINATION_TYPE_QUEUE : JMSConstants.DESTINATION_TYPE_TOPIC);
+            } else {
+                this.destination = jmsConnectionFactory.getSharedDestination();
+            }
             this.producer = jmsConnectionFactory.getMessageProducer(connection, session, destination);
         } catch (Exception e) {
             handleException("Error while creating message sender", e);
@@ -193,14 +205,22 @@ public class JMSMessageSender {
         // perform actual message sending
         try {
             if ("1.1".equals(jmsSpecVersion) || "2.0".equals(jmsSpecVersion) || isQueue == null) {
-                producer.send(message);
+                if (isProducerCachingHonoured) {
+                    producer.send(destination, message);
+                } else {
+                    producer.send(message);
+                }
                 if(session.getTransacted()) {
                     session.commit();
                 }
             } else {
                 if (isQueue) {
                     try {
-                        producer.send(message);
+                        if (isProducerCachingHonoured) {
+                            (producer).send(destination, message);
+                        } else {
+                            (producer).send(message);
+                        }
                         if(session.getTransacted()) {
                             session.commit();
                         }
@@ -208,20 +228,32 @@ public class JMSMessageSender {
                         log.error(("Error sending message with MessageContext ID : " + msgCtx.getMessageID()
                                 + " to destination : " + destination + " Hence creating a temporary subscriber" + e));
                         createTempQueueConsumer();
-                        producer.send(message);
+                        if (isProducerCachingHonoured) {
+                            producer.send(destination, message);
+                        } else {
+                            producer.send(message);
+                        }
                         if(session.getTransacted()) {
                             session.commit();
                         }
                     }
                 } else {
                     try {
-                        ((TopicPublisher) producer).publish(message);
+                        if (isProducerCachingHonoured) {
+                            ((TopicPublisher) producer).publish((Topic) destination, message);
+                        } else {
+                            ((TopicPublisher) producer).publish(message);
+                        }
                         if(session.getTransacted()) {
                             session.commit();
                         }
                     } catch (JMSException e) {
                         createTempTopicSubscriber();
-                        ((TopicPublisher) producer).publish(message);
+                        if (isProducerCachingHonoured) {
+                            ((TopicPublisher) producer).publish((Topic) destination, message);
+                        } else {
+                            ((TopicPublisher) producer).publish(message);
+                        }
                         if(session.getTransacted()) {
                             session.commit();
                         }
@@ -243,7 +275,7 @@ public class JMSMessageSender {
             if (log.isDebugEnabled()) {
                 log.debug("Sent Message Context ID : " + msgCtx.getMessageID() +
                     " with JMS Message ID : " + msgId +
-                    " to destination : " + producer.getDestination());
+                    " to destination : " + destination);
             }
 
         } catch (JMSException e) {


### PR DESCRIPTION
## Purpose
Currently in order for JMS producer caching to work, producer caching needs to be enabled and the destination needs to be specified in axis2.xml.

However in such a scenario, even when a different destination is specified in the EPR, the messages will still be sent to that specified in axis2.xml.

This PR changes the behaviour with JMS producer caching as follows:

JMS producer caching can be enabled without specifying a destination in axis2.xml
The destination specified in the EPR will be prioritized over that specified in axis2.xml
If no destination (queue/topic name) is specified in the EPR, that specified in the axis2.xml will be used
Note: Producer caching still works only when enabled in axis2.xml



## Goals
Fix https://github.com/wso2/product-ei/issues/2207



## User stories

Queue/topic name specified in EP should override what is specified in axis2.xml connectionFactory

## Release note
N/A

## Documentation

Need to update 

## Training
N/A

## Certification
N/A



## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 8 
MAC OS X
 
## Learning
N/A