### PR TITLE
FIX EI-2207-JMS Producer Caching

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
@@ -507,11 +507,29 @@ public class JMSConnectionFactory {
     public MessageProducer getMessageProducer(
         Connection connection, Session session, Destination destination) {
         if (cacheLevel > JMSConstants.CACHE_SESSION) {
-            return getSharedProducer();
+            return getNullDestinationSharedProducer();
         } else {
             return createProducer((session == null ? getSession(connection) : session), destination);
         }
     }
+
+    /**
+     * Get a shared MessageProducer from this JMS CF with destination set to null to use with multiple destinations
+     * when producer caching is enabled.
+     *
+     * @return shared MessageProducer from this JMS CF with destination set to null
+     */
+    private synchronized MessageProducer getNullDestinationSharedProducer() {
+        if (sharedProducer == null) {
+            sharedProducer = createProducer(getSharedSession(), null);
+            if (log.isDebugEnabled()) {
+                log.debug("Created shared JMS MessageConsumer with no destination specified, for JMS CF : " + name +
+                        " , with producer caching enabled");
+            }
+        }
+        return sharedProducer;
+    }
+
 
     /**
      * Get a new Connection or shared Connection from this JMS CF

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
@@ -25,9 +25,6 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.securevault.SecretResolver;
 import org.wso2.securevault.SecureVaultException;
 
-import java.util.Hashtable;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
@@ -37,7 +34,9 @@ import javax.jms.Session;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.xml.namespace.QName;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Encapsulate a JMS Connection factory definition within an Axis2.xml
@@ -523,8 +522,8 @@ public class JMSConnectionFactory {
         if (sharedProducer == null) {
             sharedProducer = createProducer(getSharedSession(), null);
             if (log.isDebugEnabled()) {
-                log.debug("Created shared JMS MessageConsumer with no destination specified, for JMS CF : " + name +
-                        " , with producer caching enabled");
+                log.debug("Created shared JMS MessageConsumer with no destination specified, for JMS CF : " + name
+                        + " , with producer caching enabled");
             }
         }
         return sharedProducer;

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -19,10 +19,10 @@
 
 package org.apache.axis2.transport.jms;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.transport.base.BaseConstants;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.jms.Connection;
 import javax.jms.DeliveryMode;
@@ -142,7 +142,7 @@ public class JMSMessageSender {
             boolean isQueue = jmsConnectionFactory.isQueue() == null ? true : jmsConnectionFactory.isQueue();
             String destinationFromAddress = JMSUtils.getDestination(targetAddress);
             //precedence is given to the destination specified by targetAddress
-            if(destinationFromAddress != null && !destinationFromAddress.isEmpty()) {
+            if (destinationFromAddress != null && !destinationFromAddress.isEmpty()) {
                 this.destination = jmsConnectionFactory.getDestination(JMSUtils.getDestination(targetAddress),
                         isQueue ? JMSConstants.DESTINATION_TYPE_QUEUE : JMSConstants.DESTINATION_TYPE_TOPIC);
             } else {
@@ -222,7 +222,7 @@ public class JMSMessageSender {
                 } else {
                     producer.send(message);
                 }
-                if(session.getTransacted()) {
+                if (session.getTransacted()) {
                     session.commit();
                 }
             } else {
@@ -233,7 +233,7 @@ public class JMSMessageSender {
                         } else {
                             (producer).send(message);
                         }
-                        if(session.getTransacted()) {
+                        if (session.getTransacted()) {
                             session.commit();
                         }
                     } catch (JMSException e) {
@@ -245,7 +245,7 @@ public class JMSMessageSender {
                         } else {
                             producer.send(message);
                         }
-                        if(session.getTransacted()) {
+                        if (session.getTransacted()) {
                             session.commit();
                         }
                     }
@@ -256,7 +256,7 @@ public class JMSMessageSender {
                         } else {
                             ((TopicPublisher) producer).publish(message);
                         }
-                        if(session.getTransacted()) {
+                        if (session.getTransacted()) {
                             session.commit();
                         }
                     } catch (JMSException e) {
@@ -266,7 +266,7 @@ public class JMSMessageSender {
                         } else {
                             ((TopicPublisher) producer).publish(message);
                         }
-                        if(session.getTransacted()) {
+                        if (session.getTransacted()) {
                             session.commit();
                         }
                     }
@@ -286,8 +286,8 @@ public class JMSMessageSender {
 
             if (log.isDebugEnabled()) {
                 log.debug("Sent Message Context ID : " + msgCtx.getMessageID() +
-                    " with JMS Message ID : " + msgId +
-                    " to destination : " + destination);
+                    " with JMS Message ID : " + msgId
+                        + " to destination : " + destination);
             }
 
         } catch (JMSException e) {


### PR DESCRIPTION
## Purpose

Currently in order for JMS producer caching to work, producer caching needs to be enabled and the destination needs to be specified in axis2.xml.

However in such a scenario, even when a different destination is specified in the EPR, the messages will still be sent to that specified in axis2.xml.

This PR changes the behaviour with JMS producer caching as follows:

JMS producer caching can be enabled without specifying a destination in axis2.xml
The destination specified in the EPR will be prioritized over that specified in axis2.xml
If no destination (queue/topic name) is specified in the EPR, that specified in the axis2.xml will be used
Note: Producer caching still works only when enabled in axis2.xml

## Goals

Fix wso2/product-ei#2207

## User stories

Queue/topic name specified in EP should override what is specified in axis2.xml connectionFactory

## Release note

N/A

## Documentation

Need to update

## Training

N/A

## Certification

N/A

## Automation tests

## Unit tests
Code coverage information
Integration tests
Details about the test cases and coverage
Security checks

## Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
Ran FindSecurityBugs plugin and verified report? yes
Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A

## Test environment

JDK 8
MAC OS X

## Learning

N/A