### PR TITLE
[Test In Progress] [ESBJAVA-4289] Dual Channel Implementation without selectors

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ConnectionDataHolder.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ConnectionDataHolder.java
@@ -143,7 +143,7 @@ class ConnectionDataHolder {
             if (null == messageProducer) {
                 synchronized (this) {
                     if (null == messageProducer) {
-                        messageProducer = createProducer(destination);
+                        messageProducer = createProducer(null);
                     }
                 }
             }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ConnectionDataHolder.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ConnectionDataHolder.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.axis2.transport.jms;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import java.util.Hashtable;
+
+/**
+ * Class to contain connection, session and producer/consumer objects. This is required to support different cache
+ * levels within the correct connection object.
+ */
+class ConnectionDataHolder {
+
+    private static final Log log = LogFactory.getLog(ConnectionDataHolder.class);
+
+    /**
+     * References to actual JMS objects used to communicate with broker.
+     */
+    private volatile Connection connection;
+    private volatile Session session;
+    private volatile MessageProducer messageProducer;
+
+    /**
+     * Cache level value based on @{@link JMSConstants}
+     */
+    private int cacheLevel = JMSConstants.CACHE_CONNECTION;
+
+    /** Reference to Axis2 JMSConnectionFactory
+     *
+     */
+    private final JMSConnectionFactory jmsConnectionFactory;
+
+    /**
+     * Configuration parameters as configured in axis2.xml for the connection factory owning this data holder.
+     */
+    private Hashtable<String, String> parameters;
+
+    /**
+     * Reference to Broker specific connection factory implementation.
+     */
+    private ConnectionFactory connectionFactory;
+
+    /**
+     * Name of Axis2.xml Connection factory
+     */
+    private final String connectionFactoryName;
+
+    /**
+     * index of this data holder in the sharedConnectionMap of @{@link JMSConnectionFactory}
+     */
+    private final int connectionIndex;
+
+    ConnectionDataHolder(ConnectionFactory connectionFactory, JMSConnectionFactory jmsConnectionFactory, int connectionIndex) {
+
+        this.jmsConnectionFactory = jmsConnectionFactory;
+
+        this.cacheLevel = jmsConnectionFactory.getCacheLevel();
+        this.parameters = jmsConnectionFactory.getParameters();
+        this.connectionFactory = connectionFactory;
+        this.connectionFactoryName = jmsConnectionFactory.getName();
+        this.connectionIndex = connectionIndex;
+    }
+
+    /**
+     * Get cached connection if cacheLevel = connection. If not, return a new connection.
+     *
+     * @return JMS Connection
+     * @throws JMSException
+     */
+    public Connection getConnection() throws JMSException {
+        if (cacheLevel > JMSConstants.CACHE_NONE) {
+            if (null == connection) {
+                synchronized (this) {
+                    if (null == connection) {
+                        connection = createConnection();
+                    }
+                }
+            }
+            return connection;
+        } else {
+            connection = createConnection();
+        }
+
+        return connection;
+    }
+
+    /**
+     * Get cached session if cacheLevel = session. If not, return a new session.
+     *
+     * @return JMS Session
+     */
+    public Session getSession() {
+
+        if (cacheLevel > JMSConstants.CACHE_CONNECTION) {
+            if (null == session) {
+                synchronized (this) {
+                    if (null == session) {
+                        session = createSession();
+                    }
+                }
+            }
+            return session;
+        } else {
+            session = createSession();
+        }
+
+        return session;
+    }
+
+    /**
+     * Get cached message producer if cacheLevel > session. If not, return a new message producer.
+     *
+     * @param destination destination to publish the message.
+     * @return JMS message producer
+     */
+    MessageProducer getMessageProducer(Destination destination) {
+        if (cacheLevel > JMSConstants.CACHE_SESSION) {
+            if (null == messageProducer) {
+                synchronized (this) {
+                    if (null == messageProducer) {
+                        messageProducer = createProducer(destination);
+                    }
+                }
+            }
+            return messageProducer;
+        } else {
+            return createProducer(destination);
+        }
+    }
+
+    /**
+     * Cleanup to ensure that all objects are closed.
+     */
+    public synchronized void close() {
+        try {
+            if (null != messageProducer)
+                messageProducer.close();
+            if (null != session) {
+                session.close();
+            }
+            if (null != connection) {
+                connection.close();
+            }
+        } catch (JMSException e) {
+            log.error("Error when trying to close connection container in Connection Factory : " +
+                    connectionFactoryName, e);
+        } finally {
+            messageProducer = null;
+            session = null;
+            connection = null;
+        }
+    }
+
+    /**
+     * Create a new JMS connection based on parameters specified in the Connection Factory as configured from
+     * axis2.xml or inline proxies.
+     *
+     * Create a new Connection
+     * @return a new Connection
+     */
+    private Connection createConnection() {
+
+        Connection connection = null;
+        try {
+            connection = JMSUtils.createConnection(
+                    connectionFactory,
+                    parameters.get(JMSConstants.PARAM_JMS_USERNAME),
+                    parameters.get(JMSConstants.PARAM_JMS_PASSWORD),
+                    JMSUtils.jmsSpecVersion(parameters), JMSUtils.isQueue(parameters, connectionFactoryName),
+                    JMSUtils.isDurable(parameters), JMSUtils.getClientId(parameters),
+                    JMSUtils.isSharedSubscription(parameters));
+            connection.setExceptionListener(new JMSExceptionListener(jmsConnectionFactory, connectionIndex));
+
+            if (log.isDebugEnabled()) {
+                log.debug("New JMS Connection from JMS CF : " + connectionFactoryName + " created");
+            }
+
+        } catch (JMSException e) {
+            JMSUtils.handleException("Error acquiring a Connection from the JMS CF : " + connectionFactoryName
+                    + " using properties : " + parameters, e);
+        }
+        return connection;
+    }
+
+    /**
+     * Create a new JMS session based on parameters specified in the Connection Factory as configured from
+     * axis2.xml or inline proxies.
+     *
+     * @return A new Session
+     */
+    private Session createSession() {
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("Creating a new JMS Session from JMS CF : " + connectionFactoryName);
+            }
+            return JMSUtils.createSession(
+                    connection, JMSUtils.isSessionTransacted(parameters), Session.AUTO_ACKNOWLEDGE,
+                    JMSUtils.jmsSpecVersion(parameters),
+                    JMSUtils.isQueue(parameters, connectionFactoryName));
+
+        } catch (JMSException e) {
+            try {
+                return JMSUtils.createSession(getConnection(), JMSUtils.isSessionTransacted(parameters), Session
+                                .AUTO_ACKNOWLEDGE,
+                        JMSUtils.jmsSpecVersion(parameters), JMSUtils.isQueue(parameters, connectionFactoryName));
+            } catch (JMSException e1) {
+                JMSUtils.handleException("Error creating JMS session from JMS CF : " + connectionFactoryName, e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Create a new JMS message producer based on parameters specified in the Connection Factory as configured from
+     * axis2.xml or inline proxies.
+     *
+     * @param destination Destination to be used
+     * @return a new MessageProducer
+     */
+    private MessageProducer createProducer(Destination destination) {
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug("Creating a new JMS MessageProducer from JMS CF : " + connectionFactoryName);
+            }
+
+            return JMSUtils.createProducer(
+                    session, destination, JMSUtils.isQueue(parameters, connectionFactoryName),
+                    JMSUtils.jmsSpecVersion(parameters));
+
+        } catch (JMSException e) {
+            JMSUtils.handleException("Error creating JMS producer from JMS CF : " + connectionFactoryName,e);
+        }
+        return null;
+    }
+
+
+}

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConnectionFactory.java
@@ -29,8 +29,6 @@ import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import javax.jms.JMSException;
-import javax.jms.MessageProducer;
-import javax.jms.Session;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -62,16 +60,12 @@ public class JMSConnectionFactory {
     private ConnectionFactory conFactory = null;
     /** The shared JMS Connection for this JMS connection factory */
     private Connection sharedConnection = null;
-    /** The shared JMS Session for this JMS connection factory */
-    private Session sharedSession = null;
-    /** The shared JMS MessageProducer for this JMS connection factory */
-    private MessageProducer sharedProducer = null;
     /** The Shared Destination */
     private Destination sharedDestination = null;
     /** The shared JMS connection for this JMS connection factory */
     private int cacheLevel = JMSConstants.CACHE_CONNECTION;
 
-    private Map<Integer, Connection> sharedConnectionMap = new ConcurrentHashMap<Integer,Connection>();
+    private Map<Integer, ConnectionDataHolder> sharedConnectionMap = new ConcurrentHashMap<>();
     private int maxSharedConnectionCount = 10;
     private int lastReturnedConnectionIndex = 0;
 
@@ -88,7 +82,7 @@ public class JMSConnectionFactory {
         try {
             pi.deserializeParameters((OMElement) parameter.getValue());
         } catch (AxisFault axisFault) {
-            handleException("Error reading parameters for JMS connection factory" + name, axisFault);
+            JMSUtils.handleException("Error reading parameters for JMS connection factory" + name, axisFault);
         }
 
         for (Object o : pi.getParameters()) {
@@ -128,7 +122,7 @@ public class JMSConnectionFactory {
         try {
             pi.deserializeParameters((OMElement) parameter.getValue());
         } catch (AxisFault axisFault) {
-            handleException("Error reading parameters for JMS connection factory" + name, axisFault);
+            JMSUtils.handleException("Error reading parameters for JMS connection factory" + name, axisFault);
         }
 
         for (Parameter param : pi.getParameters()) {
@@ -220,6 +214,8 @@ public class JMSConnectionFactory {
             }
         }
 
+        clearSharedConnections();
+
         if (context != null) {
             try {
                 context.close();
@@ -257,15 +253,15 @@ public class JMSConnectionFactory {
      * Cache level applicable for this JMS CF
      * @return applicable cache level
      */
-    public int getCacheLevel() {
+    int getCacheLevel() {
         return cacheLevel;
     }
 
     /**
      * Get the shared Destination - if defined
-     * @return
+     * @return shared JMS destination object
      */
-    public Destination getSharedDestination() {
+    Destination getSharedDestination() {
         return sharedDestination;
     }
 
@@ -279,7 +275,7 @@ public class JMSConnectionFactory {
         try {
             return JMSUtils.lookupDestination(context, destinationName, destinationType);
         } catch (NamingException e) {
-            handleException("Error looking up the JMS destination with name " + destinationName
+            JMSUtils.handleException("Error looking up the JMS destination with name " + destinationName
                     + " of type " + destinationType, e);
         }
 
@@ -287,309 +283,76 @@ public class JMSConnectionFactory {
         return null;
     }
 
-    /**
-     * Get the reply Destination from the PARAM_REPLY_DESTINATION parameter
-     * @return reply destination defined in the JMS CF
-     */
-    public String getReplyToDestination() {
-        return parameters.get(JMSConstants.PARAM_REPLY_DESTINATION);
-    }
-
-    /**
-     * Get the reply destination type from the PARAM_REPLY_DEST_TYPE parameter
-     * @return reply destination defined in the JMS CF
-     */
-    public String getReplyDestinationType() {
-        return parameters.get(JMSConstants.PARAM_REPLY_DEST_TYPE) != null ?
-                parameters.get(JMSConstants.PARAM_REPLY_DEST_TYPE) :
-                JMSConstants.DESTINATION_TYPE_GENERIC;
-    }
-
-    private void handleException(String msg, Exception e) {
-        log.error(msg, e);
-        throw new AxisJMSException(msg, e);
-    }
-
-    /**
-     * Should the JMS 1.1 API be used? - defaults to yes
-     * @return true, if JMS 1.1 api should  be used
-     */
-    public boolean isJmsSpec11() {
-        return parameters.get(JMSConstants.PARAM_JMS_SPEC_VER) == null ||
-            JMSConstants.JMS_SPEC_VERSION_1_1.equals(parameters.get(JMSConstants.PARAM_JMS_SPEC_VER));
-    }
-
-    /**
-     *  Should JMS 2.0 spec be used - default is false
-     *  Added with JMS 2.0 update
-     */
-    public boolean isJmsSpec20() {
-        return JMSConstants.JMS_SPEC_VERSION_2_0.equals(parameters.get(JMSConstants.PARAM_JMS_SPEC_VER));
-    }
-
-    /**
-     *  JMS Spec. Version. This will be used in Transport Sender
-     *  Added with JMS 2.0 update
-     */
-    public String jmsSpecVersion() {
-        if (isJmsSpec11()) {
-            return JMSConstants.JMS_SPEC_VERSION_1_1;
-        } else if (isJmsSpec20()) {
-            return JMSConstants.JMS_SPEC_VERSION_2_0;
-        } else {
-            return JMSConstants.JMS_SPEC_VERSION_1_0;
-        }
-    }
-
-    /**
-     * Return the type of the JMS CF Destination
-     * @return TRUE if a Queue, FALSE for a Topic and NULL for a JMS 1.1 Generic Destination
-     */
-    public Boolean isQueue() {
-        if (parameters.get(JMSConstants.PARAM_CONFAC_TYPE) == null &&
-            parameters.get(JMSConstants.PARAM_DEST_TYPE) == null) {
-            return null;
-        }
-
-        if (parameters.get(JMSConstants.PARAM_CONFAC_TYPE) != null) {
-            if ("queue".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_CONFAC_TYPE))) {
-                return true;
-            } else if ("topic".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_CONFAC_TYPE))) {
-                return false;
-            } else {
-                throw new AxisJMSException("Invalid " + JMSConstants.PARAM_CONFAC_TYPE + " : " +
-                    parameters.get(JMSConstants.PARAM_CONFAC_TYPE) + " for JMS CF : " + name);
-            }
-        } else {
-            if ("queue".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_DEST_TYPE))) {
-                return true;
-            } else if ("topic".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_DEST_TYPE))) {
-                return false;
-            } else {
-                throw new AxisJMSException("Invalid " + JMSConstants.PARAM_DEST_TYPE + " : " +
-                    parameters.get(JMSConstants.PARAM_DEST_TYPE) + " for JMS CF : " + name);
-            }
-        }
-    }
-
-    /**
-     * Is a session transaction requested from users of this JMS CF?
-     * @return session transaction required by the clients of this?
-     */
-    private boolean isSessionTransacted() {
-        return parameters.get(JMSConstants.PARAM_SESSION_TRANSACTED) != null &&
-            Boolean.valueOf(parameters.get(JMSConstants.PARAM_SESSION_TRANSACTED));
-    }
-
-    private boolean isDurable() {
-        if (parameters.get(JMSConstants.PARAM_SUB_DURABLE) != null) {
-            return Boolean.valueOf(parameters.get(JMSConstants.PARAM_SUB_DURABLE));
-        }
-        return false;
-    }
-
-    private boolean isSharedSubscription() {
-        if (parameters.get(JMSConstants.PARAM_IS_SHARED_SUBSCRIPTION) != null) {
-            return Boolean.valueOf(parameters.get(JMSConstants.PARAM_IS_SHARED_SUBSCRIPTION));
-        }
-        return false;
-    }
-
-    private String getClientId() {
-        return parameters.get(JMSConstants.PARAM_DURABLE_SUB_CLIENT_ID);
-    }
-
-    /**
-     * Create a new Connection
-     * @return a new Connection
-     */
-    private Connection createConnection() {
-
-        Connection connection = null;
-        try {
-            connection = JMSUtils.createConnection(
-                conFactory,
-                parameters.get(JMSConstants.PARAM_JMS_USERNAME),
-                parameters.get(JMSConstants.PARAM_JMS_PASSWORD),
-                jmsSpecVersion(), isQueue(), isDurable(), getClientId(), isSharedSubscription());
-
-            if (log.isDebugEnabled()) {
-                log.debug("New JMS Connection from JMS CF : " + name + " created");
-            }
-
-        } catch (JMSException e) {
-            handleException("Error acquiring a Connection from the JMS CF : " + name +
-                " using properties : " + JMSUtils.maskAxis2ConfigSensitiveParameters(parameters), e);
-        }
-        return connection;
-    }
-
-    /**
-     * Create a new Session
-     * @param connection Connection to use
-     * @return A new Session
-     */
-    private Session createSession(Connection connection) {
-        try {
-            if (log.isDebugEnabled()) {
-                log.debug("Creating a new JMS Session from JMS CF : " + name);
-            }
-            return JMSUtils.createSession(
-                connection, isSessionTransacted(), Session.AUTO_ACKNOWLEDGE, jmsSpecVersion(), isQueue());
-
-        } catch (JMSException e) {
-            try {
-                clearSharedConnections();
-                return JMSUtils.createSession(getConnection(), isSessionTransacted(), Session.AUTO_ACKNOWLEDGE,
-                        jmsSpecVersion(), isQueue());
-            } catch (JMSException e1) {
-                handleException("Error creating JMS session from JMS CF : " + name, e);
-            }
-            log.info("Detected a stale connection. Hence refreshing the connection cache map.");
-        }
-        return null;
-    }
-
-    /**
-     * Create a new MessageProducer
-     * @param session Session to be used
-     * @param destination Destination to be used
-     * @return a new MessageProducer
-     */
-    private MessageProducer createProducer(Session session, Destination destination) {
-        try {
-            if (log.isDebugEnabled()) {
-                log.debug("Creating a new JMS MessageProducer from JMS CF : " + name);
-            }
-
-            return JMSUtils.createProducer(
-                session, destination, isQueue(), jmsSpecVersion());
-
-        } catch (JMSException e) {
-            handleException("Error creating JMS producer from JMS CF : " + name,e);
-        }
-        return null;
-    }
-
-    /**
-     * Get a new Connection or shared Connection from this JMS CF
-     * @return new or shared Connection from this JMS CF
-     */
-    public Connection getConnection() {
+    ConnectionDataHolder getConnectionContainer() {
         if (cacheLevel > JMSConstants.CACHE_NONE) {
-            return getSharedConnection();
+            return getSharedConnectionContainer();
         } else {
-            return createConnection();
+            return new ConnectionDataHolder(conFactory, this, 0);
         }
     }
 
-    /**
-     * Get a new Session or shared Session from this JMS CF
-     * @param connection the Connection to be used
-     * @return new or shared Session from this JMS CF
-     */
-    public Session getSession(Connection connection) {
-        if (cacheLevel > JMSConstants.CACHE_CONNECTION) {
-            return getSharedSession();
-        } else {
-            return createSession((connection == null ? getConnection() : connection));
-        }
-    }
+    private synchronized ConnectionDataHolder getSharedConnectionContainer() {
+        ConnectionDataHolder connectionDataHolder = sharedConnectionMap.get(lastReturnedConnectionIndex);
 
-    /**
-     * Get a new MessageProducer or shared MessageProducer from this JMS CF
-     * @param connection the Connection to be used
-     * @param session the Session to be used
-     * @param destination the Destination to bind MessageProducer to
-     * @return new or shared MessageProducer from this JMS CF
-     */
-    public MessageProducer getMessageProducer(
-        Connection connection, Session session, Destination destination) {
-        if (cacheLevel > JMSConstants.CACHE_SESSION) {
-            return getNullDestinationSharedProducer();
-        } else {
-            return createProducer((session == null ? getSession(connection) : session), destination);
-        }
-    }
-
-    /**
-     * Get a shared MessageProducer from this JMS CF with destination set to null to use with multiple destinations
-     * when producer caching is enabled.
-     *
-     * @return shared MessageProducer from this JMS CF with destination set to null
-     */
-    private synchronized MessageProducer getNullDestinationSharedProducer() {
-        if (sharedProducer == null) {
-            sharedProducer = createProducer(getSharedSession(), null);
-            if (log.isDebugEnabled()) {
-                log.debug("Created shared JMS MessageConsumer with no destination specified, for JMS CF : " + name
-                        + " , with producer caching enabled");
-            }
-        }
-        return sharedProducer;
-    }
-
-
-    /**
-     * Get a new Connection or shared Connection from this JMS CF
-     * @return new or shared Connection from this JMS CF
-     */
-    private synchronized Connection getSharedConnection() {
-
-        Connection connection = sharedConnectionMap.get(lastReturnedConnectionIndex);
-        if (connection == null) {
-            connection = createConnection();
-            sharedConnectionMap.put(lastReturnedConnectionIndex, connection);
+        if ((null == connectionDataHolder) && (sharedConnectionMap.size() <= maxSharedConnectionCount)) {
+            connectionDataHolder = new ConnectionDataHolder(conFactory, this, lastReturnedConnectionIndex);
+            sharedConnectionMap.put(lastReturnedConnectionIndex, connectionDataHolder);
         }
         lastReturnedConnectionIndex++;
         if (lastReturnedConnectionIndex >= maxSharedConnectionCount) {
             lastReturnedConnectionIndex = 0;
         }
-        return connection;
-    }
 
-    /**
-     * Get a shared Session from this JMS CF
-     * @return shared Session from this JMS CF
-     */
-    private synchronized Session getSharedSession() {
-        if (sharedSession == null) {
-            sharedSession = createSession(getSharedConnection());
-            if (log.isDebugEnabled()) {
-                log.debug("Created shared JMS Session for JMS CF : " + name);
-            }
-        }
-        return sharedSession;
-    }
-
-    /**
-     * Get a shared MessageProducer from this JMS CF
-     * @return shared MessageProducer from this JMS CF
-     */
-    private synchronized MessageProducer getSharedProducer() {
-        if (sharedProducer == null) {
-            sharedProducer = createProducer(getSharedSession(), sharedDestination);
-            if (log.isDebugEnabled()) {
-                log.debug("Created shared JMS MessageConsumer for JMS CF : " + name);
-            }
-        }
-        return sharedProducer;
+        return connectionDataHolder;
     }
 
     /**
      * Clear the shared connection map due to stale connections
      */
     private synchronized void clearSharedConnections() {
-        for (Map.Entry<Integer, Connection> connectionMap : sharedConnectionMap.entrySet()) {
-            try {
-                if (connectionMap.getValue() != null) {
-                    connectionMap.getValue().close();
-                }
-            } catch (JMSException e) {
-                log.warn("Error while shutting down the connection : ", e);
-            }
+        for (Map.Entry<Integer, ConnectionDataHolder> entry : sharedConnectionMap.entrySet()) {
+            entry.getValue().close();
         }
         sharedConnectionMap.clear();
         lastReturnedConnectionIndex = 0;
     }
+
+    /**
+     * Get the reply destination type from the PARAM_REPLY_DEST_TYPE parameter
+     * @return reply destination defined in the JMS CF
+     */
+    String getReplyDestinationType() {
+        return parameters.get(JMSConstants.PARAM_REPLY_DEST_TYPE) != null ?
+                parameters.get(JMSConstants.PARAM_REPLY_DEST_TYPE) : JMSConstants.DESTINATION_TYPE_GENERIC;
+    }
+
+    /**
+     *  JMS Spec. Version. This will be used in Transport Sender
+     *  Added with JMS 2.0 update
+     */
+    String jmsSpecVersion() {
+        return JMSUtils.jmsSpecVersion(parameters);
+    }
+
+    /**
+     * Return the type of the JMS CF Destination
+     * @return TRUE if a Queue, FALSE for a Topic and NULL for a JMS 1.1 Generic Destination
+     */
+    Boolean isQueue() {
+        return JMSUtils.isQueue(parameters, name);
+    }
+
+    /**
+     * In case of a broker failure, remove cached connections in order to attempt new connections.
+     * @param connectionIndex index of connection container
+     */
+    public void clearCachedConnection(int connectionIndex) {
+        ConnectionDataHolder connectionDataHolder = sharedConnectionMap.get(connectionIndex);
+
+        if (null != connectionDataHolder) {
+            connectionDataHolder.close();
+            sharedConnectionMap.remove(connectionIndex);
+        }
+    }
+
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSExceptionListener.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSExceptionListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.axis2.transport.jms;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+
+/**
+ * Custom exception listener to handle failure of cached JMS connections in JMS Connection Factory Instances.
+ */
+public class JMSExceptionListener implements ExceptionListener {
+
+    private static final Log log = LogFactory.getLog(JMSExceptionListener.class);
+
+    private JMSConnectionFactory jmsConnectionFactory;
+    private final int connectionIndex;
+
+    JMSExceptionListener(JMSConnectionFactory jmsConnectionFactory, int connectionIndex) {
+        this.jmsConnectionFactory = jmsConnectionFactory;
+        this.connectionIndex = connectionIndex;
+    }
+
+    @Override
+    public void onException(JMSException e) {
+
+        log.warn("Cached connection will be cleared due to JMSException on : " + connectionIndex, e);
+        jmsConnectionFactory.clearCachedConnection(connectionIndex);
+    }
+}

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -50,6 +50,11 @@ public class JMSMessageSender {
 
     private static final Log log = LogFactory.getLog(JMSMessageSender.class);
 
+    /**
+     * The encapsulated connection, session and producer objects which can be cached.
+     */
+    private ConnectionDataHolder connectionDataHolder = null;
+
     /** The Connection to be used to send out */
     private Connection connection = null;
     /** The Session to be used to send out */
@@ -88,8 +93,10 @@ public class JMSMessageSender {
      * @param isQueue posting to a Queue?
      */
     public JMSMessageSender(Connection connection, Session session, MessageProducer producer,
-        Destination destination, int cacheLevel, String jmsSpecVersion, Boolean isQueue) {
+                            Destination destination, int cacheLevel, String jmsSpecVersion, Boolean isQueue,
+                            ConnectionDataHolder connectionDataHolder) {
 
+        this.connectionDataHolder = connectionDataHolder;
         this.connection = connection;
         this.session = session;
         this.producer = producer;
@@ -137,8 +144,9 @@ public class JMSMessageSender {
             this.cacheLevel = jmsConnectionFactory.getCacheLevel();
             this.isProducerCachingHonoured = cacheLevel > JMSConstants.CACHE_SESSION;
             this.jmsSpecVersion = jmsConnectionFactory.jmsSpecVersion();
-            this.connection = jmsConnectionFactory.getConnection();
-            this.session = jmsConnectionFactory.getSession(connection);
+            this.connectionDataHolder = jmsConnectionFactory.getConnectionContainer();
+            this.connection = connectionDataHolder.getConnection();
+            this.session = connectionDataHolder.getSession();
             boolean isQueue = jmsConnectionFactory.isQueue() == null ? true : jmsConnectionFactory.isQueue();
             String destinationFromAddress = JMSUtils.getDestination(targetAddress);
             //precedence is given to the destination specified by targetAddress
@@ -148,7 +156,7 @@ public class JMSMessageSender {
             } else {
                 this.destination = jmsConnectionFactory.getSharedDestination();
             }
-            this.producer = jmsConnectionFactory.getMessageProducer(connection, session, destination);
+            this.producer = connectionDataHolder.getMessageProducer(destination);
         } catch (Exception e) {
             handleException("Error while creating message sender", e);
         }
@@ -360,7 +368,7 @@ public class JMSMessageSender {
      * Close non-shared producer, session and connection if any
      */
     public void close() {
-        if (producer != null && cacheLevel < JMSConstants.CACHE_PRODUCER) {
+        if (producer != null && cacheLevel < JMSConstants.CACHE_CONSUMER) {
             try {
                 producer.close();
             } catch (JMSException e) {
@@ -438,6 +446,14 @@ public class JMSMessageSender {
                 connection = null;
             }
         }
+
+        if (null != connectionDataHolder) {
+            connectionDataHolder.close();
+        }
+    }
+
+    public void setConnectionDataHolder(ConnectionDataHolder connectionDataHolder) {
+        this.connectionDataHolder = connectionDataHolder;
     }
 
     private boolean isTransacted() {

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSOutTransportInfo.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSOutTransportInfo.java
@@ -458,14 +458,22 @@ public class JMSOutTransportInfo implements OutTransportInfo {
                 }
             }
 
-            if (connection == null) {
-                connection = jmsConnectionFactory != null ? jmsConnectionFactory.getConnection() : null;
-            }
+            ConnectionDataHolder connectionDataHolder = null;
 
             Session session = null;
             MessageProducer producer = null;
 
-            if (connection != null) {
+            // If the connection cannot be created from configured JMS connection factory, and if there is a axis2.xml
+            // connection factory specified, create/ re-use an existing connection from the axis2.xml factory.
+            if ((connection == null) && (jmsConnectionFactory != null)) {
+                connectionDataHolder = jmsConnectionFactory.getConnectionContainer();
+                connection = connectionDataHolder.getConnection();
+                session = connectionDataHolder.getSession();
+                producer = connectionDataHolder.getMessageProducer(destination);
+            }
+
+            // If for some reason a session/ producer cannot be created from above logic, create new instances.
+            if ((connection != null) && (session == null)) {
                 if (destType == JMSConstants.QUEUE) {
                     session = ((QueueConnection) connection).
                             createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
@@ -495,7 +503,8 @@ public class JMSOutTransportInfo implements OutTransportInfo {
                             this.cacheLevel : jmsConnectionFactory.getCacheLevel(),
                     jmsSpecVersion,
                     destType == -1 ?
-                            null : destType == JMSConstants.QUEUE ? Boolean.TRUE : Boolean.FALSE
+                            null : destType == JMSConstants.QUEUE ? Boolean.TRUE : Boolean.FALSE,
+                    connectionDataHolder
             );
         }
 

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
@@ -71,6 +71,7 @@ import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;
 import javax.naming.Reference;
+import java.util.Hashtable;
 
 /**
  * Miscallaneous methods used for the JMS transport
@@ -1046,5 +1047,128 @@ public class JMSUtils extends BaseUtils {
         }
 
         return maskedParamsTable;
+    }
+
+
+    /**
+     * Should the JMS 1.1 API be used? - defaults to yes
+     *
+     * @param parameters Connection factory parameters
+     * @return true, if JMS 1.1 api should  be used
+     */
+    private static boolean isJmsSpec11(Hashtable<String, String> parameters) {
+        return parameters.get(JMSConstants.PARAM_JMS_SPEC_VER) == null ||
+                JMSConstants.JMS_SPEC_VERSION_1_1.equals(parameters.get(JMSConstants.PARAM_JMS_SPEC_VER));
+    }
+
+    /**
+     * Should JMS 2.0 spec be used - default is false
+     * Added with JMS 2.0 update
+     *
+     * @param parameters Connection factory parameters
+     */
+    private static boolean isJmsSpec20(Hashtable<String, String> parameters) {
+        return JMSConstants.JMS_SPEC_VERSION_2_0.equals(parameters.get(JMSConstants.PARAM_JMS_SPEC_VER));
+    }
+
+    /**
+     * JMS Spec. Version. This will be used in Transport Sender
+     * Added with JMS 2.0 update
+     *
+     * @param parameters Connection factory parameters
+     */
+    public static String jmsSpecVersion(Hashtable<String, String> parameters) {
+        if (isJmsSpec11(parameters)) {
+            return JMSConstants.JMS_SPEC_VERSION_1_1;
+        } else if (isJmsSpec20(parameters)) {
+            return JMSConstants.JMS_SPEC_VERSION_2_0;
+        } else {
+            return JMSConstants.JMS_SPEC_VERSION_1_0;
+        }
+    }
+
+    /**
+     * Return the type of the JMS CF Destination
+     *
+     * @param parameters Connection factory parameters
+     * @return TRUE if a Queue, FALSE for a Topic and NULL for a JMS 1.1 Generic Destination
+     */
+    public static Boolean isQueue(Hashtable<String, String> parameters, String connectionFactoryName) {
+        if (parameters.get(JMSConstants.PARAM_CONFAC_TYPE) == null &&
+                parameters.get(JMSConstants.PARAM_DEST_TYPE) == null) {
+            return null;
+        }
+
+        if (parameters.get(JMSConstants.PARAM_CONFAC_TYPE) != null) {
+            if ("queue".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_CONFAC_TYPE))) {
+                return true;
+            } else if ("topic".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_CONFAC_TYPE))) {
+                return false;
+            } else {
+                throw new AxisJMSException("Invalid " + JMSConstants.PARAM_CONFAC_TYPE + " : " +
+                        parameters.get(JMSConstants.PARAM_CONFAC_TYPE) + " for JMS CF : " + connectionFactoryName);
+            }
+        } else {
+            if ("queue".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_DEST_TYPE))) {
+                return true;
+            } else if ("topic".equalsIgnoreCase(parameters.get(JMSConstants.PARAM_DEST_TYPE))) {
+                return false;
+            } else {
+                throw new AxisJMSException("Invalid " + JMSConstants.PARAM_DEST_TYPE + " : " +
+                        parameters.get(JMSConstants.PARAM_DEST_TYPE) + " for JMS CF : " + connectionFactoryName);
+            }
+        }
+    }
+
+    /**
+     * Is a session transaction requested from users of this JMS CF?
+     *
+     * @param parameters Connection factory parameters
+     * @return session transaction required by the clients of this?
+     */
+    public static boolean isSessionTransacted(Hashtable<String, String> parameters) {
+        return parameters.get(JMSConstants.PARAM_SESSION_TRANSACTED) != null &&
+                Boolean.valueOf(parameters.get(JMSConstants.PARAM_SESSION_TRANSACTED));
+    }
+
+    /**
+     * @param parameters Connection factory parameters
+     * @return true if the JMS subscription is durable.
+     */
+    public static boolean isDurable(Hashtable<String, String> parameters) {
+        if (parameters.get(JMSConstants.PARAM_SUB_DURABLE) != null) {
+            return Boolean.valueOf(parameters.get(JMSConstants.PARAM_SUB_DURABLE));
+        }
+        return false;
+    }
+
+    /**
+     * @param parameters Connection factory parameters
+     * @return true if the subscription is shared using the same subscription ID for multiple subscribers.
+     */
+    public static boolean isSharedSubscription(Hashtable<String, String> parameters) {
+        if (parameters.get(JMSConstants.PARAM_IS_SHARED_SUBSCRIPTION) != null) {
+            return Boolean.valueOf(parameters.get(JMSConstants.PARAM_IS_SHARED_SUBSCRIPTION));
+        }
+        return false;
+    }
+
+    /**
+     * @param parameters Connection factory parameters
+     * @return Client ID of the JMS subscription.
+     */
+    public static String getClientId(Hashtable<String, String> parameters) {
+        return parameters.get(JMSConstants.PARAM_DURABLE_SUB_CLIENT_ID);
+    }
+
+    /**
+     * Common method to wrap and propagate JMS related exceptions.
+     *
+     * @param msg error message
+     * @param e   exception
+     */
+    public static void handleException(String msg, Exception e) {
+        log.error(msg, e);
+        throw new AxisJMSException(msg, e);
     }
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/JMSReplyContainer.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/JMSReplyContainer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.axis2.transport.jms.dualchannel;
+
+
+import javax.jms.Message;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * DataHolder containing a latch so that the JMSSender can be notified of its response message.
+ */
+public class JMSReplyContainer {
+
+    /**
+     * Latch to signal availability of response message.
+     */
+    private CountDownLatch countDownLatch;
+
+    /**
+     * JMS response message.
+     */
+    private Message message;
+
+    public JMSReplyContainer(CountDownLatch countDownLatch) {
+        this.countDownLatch = countDownLatch;
+    }
+
+    CountDownLatch getCountDownLatch() {
+        return countDownLatch;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+
+    public void setMessage(Message message) {
+        this.message = message;
+    }
+}

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/JMSReplyHandler.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/JMSReplyHandler.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.axis2.transport.jms.dualchannel;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import javax.jms.JMSException;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.net.SocketException;
+import java.util.Hashtable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Provide access to cached Subscriptions per proxy to the JMSSender for waiting for the response.
+ * Create cached subscriptions to a queueName local to the ESB node + proxy.
+ *
+ * When the first JMS request asks for a subscription, the handler will
+ * 1. create a JMS subscription (@{@link JMSReplySubscription}) for that specific reply queue, and schedule it to run
+ *    every X seconds (@SUBSCRIPTION_POLL_INTERVAL).
+ * 2. Add a listener to the correlationId of the JMS request, so that the Sender is notified of the response.
+ */
+public class JMSReplyHandler {
+
+    private static final Log log;
+
+    /**
+     * Interval between running all tasks in @scheduledThreadPoolExecutor. (Per each run, the task will messages from
+     * subscriptions until an empty response is received.)
+     */
+    private static final long SUBSCRIPTION_POLL_INTERVAL = 1;
+
+    /**
+     * Scheduled executor to trigger consumption of messages periodically for all Reply Subscriptions.
+     */
+    private ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
+
+    /**
+     * One time instance
+     */
+    private static JMSReplyHandler jmsReplyHandler;
+
+    /**
+     * Map containing all active subscribers (per proxy) listening for reply messages.
+     */
+    private ConcurrentHashMap<String, JMSReplySubscription> replySubscriptionMap;
+
+    /**
+     * Port opened for proxy services.
+     */
+    private static String servicePort = "";
+
+    /**
+     * IP address
+     */
+    private static String ipAddress;
+
+    static {
+        log = LogFactory.getLog(JMSReplyHandler.class);
+        jmsReplyHandler = new JMSReplyHandler();
+
+        // Evaluate the IP address at initialization for use when generating a unique identifier for each subscription.
+        try {
+            ipAddress = org.apache.axis2.util.Utils.getIpAddress().replace(".", "");
+        } catch (SocketException e) {
+            log.error("Could not resolve the IP address", e);
+        }
+    }
+
+    public static JMSReplyHandler getInstance() {
+        return jmsReplyHandler;
+    }
+
+    private JMSReplyHandler() {
+
+        scheduledThreadPoolExecutor = (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(10, new
+                JMSReplyThreadFactory("jms-reply-handler"));
+        scheduledThreadPoolExecutor.setRemoveOnCancelPolicy(true);
+
+        replySubscriptionMap = new ConcurrentHashMap<>();
+    }
+
+    /**
+     * Get existing subscription and create a new one if none exists.
+     *
+     * @param identifier unique identifier for subscription as key for the @replySubscriptionMap
+     * @param initialContext JNDI context used to initialize a connection
+     * @param connectionFactoryName name of axis2.xml connection factory.
+     * @return active subscription for registering a listener for a reply message.
+     * @throws JMSException
+     * @throws NamingException
+     */
+    public JMSReplySubscription getReplySubscription(String identifier, InitialContext initialContext, String
+            connectionFactoryName) throws JMSException, NamingException {
+
+        JMSReplySubscription jmsReplySubscription;
+
+        jmsReplySubscription = replySubscriptionMap.get(identifier);
+
+        if (null == jmsReplySubscription) {
+            synchronized (identifier.intern()) {
+                jmsReplySubscription = replySubscriptionMap.get(identifier);
+
+                if (null == jmsReplySubscription) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Active subscription NOT found for : " + identifier);
+                    }
+
+                    jmsReplySubscription = new JMSReplySubscription(initialContext, connectionFactoryName, identifier);
+                    ScheduledFuture<?> scheduledFuture = scheduledThreadPoolExecutor.
+                            scheduleWithFixedDelay(jmsReplySubscription, 0, SUBSCRIPTION_POLL_INTERVAL, TimeUnit.SECONDS);
+
+                    jmsReplySubscription.setTaskReference(scheduledFuture);
+
+                    replySubscriptionMap.put(identifier, jmsReplySubscription);
+                }
+            }
+        }
+
+        return jmsReplySubscription;
+    }
+
+    /**
+     * In case of a broker failure, remove the subscription in order to attempt for a new instance.
+     * @param identifier unique identifier for subscription
+     */
+    public void removeReplySubscription(String identifier) {
+
+        if (replySubscriptionMap.containsKey(identifier)) {
+            replySubscriptionMap.get(identifier).cleanupTask();
+            replySubscriptionMap.remove(identifier);
+        }
+    }
+
+    /**
+     * Generate a unique ID to relate to the subscription.
+     * @param servicePath Service path from message context.
+     * @param servicePrefix to infer an open port within the ESB node
+     * @return a unique queue name
+     */
+    public static String generateSubscriptionIdentifier(String servicePath, String servicePrefix) {
+
+        // if set once, we do not need to re-evaluate the port.
+        if (StringUtils.isBlank(servicePort)) {
+            if (!StringUtils.isEmpty(servicePrefix)) {
+                servicePort = servicePrefix.split(":")[2];
+            }
+        }
+
+        String proxyName = retrieveServiceName(servicePath);
+        return  proxyName + ipAddress + servicePort;
+    }
+
+    /**
+     * Retrieve service name given the path from message context.
+     * @param servicePath (e.g. /services/SMSSenderProxy.SOAP11Endpoint)
+     * @return proxy service name (e.g. SMSSenderProxy.SOAP11Endpoint)
+     */
+    private static String retrieveServiceName(String servicePath) {
+
+        String serviceName = "";
+
+        String[] tokens = servicePath.split("/");
+        if (tokens.length > 0) {
+            serviceName = tokens[tokens.length - 1];
+        }
+
+        return serviceName;
+    }
+
+    /**
+     * Custom thread factory to name threads using a common convention.
+     */
+    private class JMSReplyThreadFactory implements ThreadFactory {
+
+        private final String name;
+        private final AtomicInteger integer = new AtomicInteger(1);
+
+        JMSReplyThreadFactory(String name) {
+            this.name = name;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Thread newThread(Runnable r) {
+            return new Thread(r, name + integer.getAndIncrement());
+        }
+    }
+}

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/JMSReplySubscription.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/JMSReplySubscription.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.axis2.transport.jms.dualchannel;
+
+
+import org.apache.axis2.transport.jms.JMSConstants;
+import org.apache.axis2.transport.jms.JMSUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Data holder for a cached subscription meant for consuming reply messages. Once a new request arrives for the
+ * relevant proxy, the JMSSender will attach a @{@link JMSReplyContainer} to this subscription with its
+ * request correlation Id. When the subscription receives a matching reply, it will notify the JMSSender.
+ */
+public class JMSReplySubscription implements Runnable {
+
+    private static final Log log = LogFactory.getLog(JMSReplySubscription.class);
+    private static final int CONSUME_TIMEOUT = 1000;
+
+    /**
+     * Broker specific message consumer, connection, session references.
+     */
+    private MessageConsumer messageConsumer;
+    private Connection connection;
+    private Session session;
+
+    /**
+     * Map for maintaining active requests for the relevant proxy.
+     */
+    private ConcurrentHashMap<String, JMSReplyContainer> listeningRequests;
+
+    /**
+     * Reference to periodic task which triggers a consumer.receive.
+     */
+    private ScheduledFuture taskReference;
+
+    /**
+     * Unique identifier for this subscription based on proxy name, server IP and queue name.
+     */
+    private String identifier;
+
+    /**
+     * Temporary queue on which this subscription is listening for the replies.
+     */
+    private TemporaryQueue temporaryQueue;
+
+    /**
+     * Lock to ensure that updates to the subscription / its listeners are updated consistently.
+     */
+    private Lock lock = new ReentrantLock();
+
+    JMSReplySubscription(InitialContext initialContext, String connectionFactoryName, String identifier)
+            throws NamingException, JMSException {
+
+        this.identifier = identifier;
+        listeningRequests = new ConcurrentHashMap<>();
+
+        ConnectionFactory connectionFactory = JMSUtils.lookup(initialContext, ConnectionFactory.class, connectionFactoryName);
+
+        String username = null;
+        String password = null;
+
+        if (initialContext.getEnvironment().containsKey(JMSConstants.PARAM_JMS_PASSWORD)) {
+            username = (String) initialContext.getEnvironment().get(JMSConstants.PARAM_JMS_USERNAME);
+            password = (String) initialContext.getEnvironment().get(JMSConstants.PARAM_JMS_PASSWORD);
+        }
+
+        connection = JMSUtils.createConnection(connectionFactory, username, password, JMSConstants.JMS_SPEC_VERSION_1_1,
+                true, false, null, false);
+        connection.setExceptionListener(new ReplySubscriptionExceptionListener(identifier));
+        connection.start();
+
+        session = JMSUtils.createSession(connection, false, Session.AUTO_ACKNOWLEDGE, JMSConstants.JMS_SPEC_VERSION_1_1, true);
+
+        temporaryQueue = session.createTemporaryQueue();
+
+        messageConsumer = JMSUtils.createConsumer(session, temporaryQueue, "");
+
+    }
+
+    /**
+     * After sending a JMS message with a ReplyTo header, the JMSSender can register a listener here to be notified
+     * of the response.
+     * @param jmsCorrelationId correlation ID used to correlate the request to response message.
+     * @param replyContainer Object used to listen to, and retrieve the response message.
+     */
+    public void registerListener(String jmsCorrelationId, JMSReplyContainer replyContainer) {
+        listeningRequests.put(jmsCorrelationId, replyContainer);
+    }
+
+    /**
+     * Remove listener to a specific JMS request.
+     * @param jmsCorrelationId correlation ID used to correlate the request to response message.
+     */
+    public void unregisterListener(String jmsCorrelationId) {
+        listeningRequests.remove(jmsCorrelationId);
+    }
+
+    public TemporaryQueue getTemporaryQueue() {
+        return temporaryQueue;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Message message = messageConsumer.receive(CONSUME_TIMEOUT);
+
+            while (null != message) {
+
+                String jmsCorrelationId = message.getJMSCorrelationID();
+                if (log.isDebugEnabled()) {
+                    log.debug("Received correlationId : " + jmsCorrelationId + " identifier : " + identifier);
+                }
+                JMSReplyContainer jmsReplyContainer = listeningRequests.get(jmsCorrelationId);
+
+                if (null != jmsReplyContainer) {
+                    jmsReplyContainer.setMessage(message);
+                    jmsReplyContainer.getCountDownLatch().countDown();
+                }
+
+                message = messageConsumer.receive(CONSUME_TIMEOUT);
+            }
+
+        } catch (JMSException e) {
+            log.error("Error while receiving message : ", e);
+        }
+    }
+
+
+    /**
+     * Maintain reference to ScheduledFuture running the scheduled task.
+     * @param taskReference reference to ScheduledFuture running the scheduled task
+     */
+    void setTaskReference(ScheduledFuture taskReference) {
+        this.taskReference = taskReference;
+    }
+
+    /**
+     * Announce closing of this subscription to any listeners still waiting for a reply, and cancel the scheduled task.
+     */
+    void cleanupTask() {
+
+        // No locks required since this is a concurrent hash map.
+        for (Map.Entry<String,JMSReplyContainer> request : listeningRequests.entrySet()) {
+            request.getValue().getCountDownLatch().countDown();
+        }
+        taskReference.cancel(true);
+
+        if (log.isDebugEnabled()) {
+            log.debug(" Cancelled task for reply subscription identified with : " + identifier);
+        }
+
+        lock.lock();
+        try {
+            messageConsumer.close();
+            session.close();
+            connection.close();
+        } catch (JMSException e) {
+            log.error("Error when trying to close JMS reply subscription for identifier : " + identifier, e);
+        } finally {
+            messageConsumer = null;
+            session = null;
+            connection = null;
+        }
+
+        lock.unlock();
+
+    }
+
+}

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/ReplySubscriptionExceptionListener.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/dualchannel/ReplySubscriptionExceptionListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.axis2.transport.jms.dualchannel;
+
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+
+/**
+ * Custom exception listener to handle failure of a JMS subscriber connection in the Dual-Channel scenario.
+ */
+class ReplySubscriptionExceptionListener implements ExceptionListener {
+
+    private static final Log log = LogFactory.getLog(ReplySubscriptionExceptionListener.class);
+
+    private String identifier;
+
+    ReplySubscriptionExceptionListener(String identifier) {
+        this.identifier = identifier;
+    }
+
+    @Override
+    public void onException(JMSException e) {
+
+        synchronized (identifier.intern()) {
+            log.warn("Cached subscription will be cleared due to JMSException on : " + identifier, e);
+            JMSReplyHandler.getInstance().removeReplySubscription(identifier);
+        }
+    }
+}

--- a/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
+++ b/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
@@ -104,7 +104,9 @@ public class JMSSenderTestCase extends TestCase {
         //append the transport.jms.TransactionCommand
         String targetAddress = "jms:/SimpleStockQuoteService?transport.jms.ConnectionFactoryJNDIName="
                 + "QueueConnectionFactory&transport.jms.TransactionCommand=begin"
-                + "&java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory";
+                + "&java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory"
+                + "&transport.jms.DestinationType=queue";
+        PowerMockito.doReturn(targetAddress).when(jmsOutTransportInfo).getTargetEPR();
         Transaction transaction = new TestJMSTransaction();
         messageContext.setProperty(JMSConstants.JMS_XA_TRANSACTION, transaction);
 


### PR DESCRIPTION
## Previous Implementation : 

Once a JMS message is received with a ReplyTo destination : 

1. Message goes through normal pre-processing at JMSSender.sendMessage() and moves to sendOverJMS() method. 
2. Based on where the connection properties are defined (inline endpoint or axis2.xml), the ReplyDestination object is created and set to the Message.setReplyTo header. 
3. Message is sent to the destination. 
4. The message correlationID is set equal to the JMS_MESSAGE_ID, if a correlationId is not specified at the proxy.
5. At the waitForResponseAndProcess() method, a new JMS consumer is created with a selecter ( on correlationId) to get the response message, using the same JMS session used to publish the message.

Motive for the new implementation is to avoid using selectors in this flow **when a reply destination is not defined**, and re-use JMS consumers when the same proxy is invoked. 

## New Implementation : 

1. Message goes through normal pre-processing at JMSSender.sendMessage() and moves to sendOverJMS() method.
2. The connection properties are evaluated from the inline endpoint url or a pre-defined JMSSender configured in axis2.xml. 

3. a. IF the ReplyDestination is NOT defined, use a cached subscription on a temporary queue to consume the response message without selectors. 
~ 1 cached subscription per proxy local to each ESB node. 

3. b. IF the ReplyDestination is defined, execute the "previous implementation" which uses selectors on a consumer to the defined ReplyDestination. 

## Caching sessions when sending messages from JMSConnectionFactory

Previous implementation used a single shared session across one JMSConnectionFactory when cacheLevel = session. This causes different connections to be associated with the same session when publishing messages. To avoid this, this PR creates a ConnectionContainer to maintain the connection+session+producer mapping in the cache, and re-use together.

* This issue is quite visible when testing with IBMMQ, where even though we cache 10 connection objects by default, newer sockets are opened to publish each message without re-using the existing connections. 

## Special cases : 

If a connection failure occurs, any cached subscriptions will be closed, and their respective message listeners will be signalled and removed, causing the listening requests to respond with an empty reply.
  
  