### PR TITLE
Resolve product-ei/issues/2776

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -333,6 +333,11 @@ public class JMSConstants {
       * */
      public static final String QUEUE_PREFIX = "queue.";
 
+    /**
+     *  The content type of a receiving payload
+     */
+    public static final String CONTENT_TYPE = "ContentType";
+
      /**
       * Andes Naming Factory
       * */

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -336,7 +336,7 @@ public class JMSConstants {
     /**
      *  The content type of a receiving payload
      */
-    public static final String CONTENT_TYPE = "ContentType";
+    public static final String MESSAGE_TYPE = "messageType";
 
      /**
       * Andes Naming Factory

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -175,7 +175,9 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         // Fix for ESBJAVA-3687, retrieve JMS transport property transport.jms.MessagePropertyHyphens and set this
         // into the msgCtx
         String hyphenSupport = JMSConstants.DEFAULT_HYPHEN_SUPPORT;
-        if (jmsOut.getProperties() != null && jmsOut.getProperties().get(JMSConstants.PARAM_JMS_HYPHEN_MODE) != null) {
+        if (jmsConnectionFactory != null && jmsConnectionFactory.getParameters().get(JMSConstants.PARAM_JMS_HYPHEN_MODE) != null){
+            hyphenSupport = jmsConnectionFactory.getParameters().get(JMSConstants.PARAM_JMS_HYPHEN_MODE);
+        } else if (jmsOut.getProperties() != null && jmsOut.getProperties().get(JMSConstants.PARAM_JMS_HYPHEN_MODE) != null) {
             if (jmsOut.getProperties().get(JMSConstants.PARAM_JMS_HYPHEN_MODE).equals(JMSConstants.HYPHEN_MODE_REPLACE)) {
                 hyphenSupport = JMSConstants.HYPHEN_MODE_REPLACE;
             } else if (jmsOut.getProperties().get(JMSConstants.PARAM_JMS_HYPHEN_MODE).equals(JMSConstants.HYPHEN_MODE_DELETE)) {

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -622,7 +622,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         // load any transport headers from received message
         JMSUtils.loadTransportHeaders(message, responseMsgCtx);
 
-        String contentType = contentTypeProperty == outMsgCtx.getProperty(JMSConstants.CONTENT_TYPE) ? null
+        String contentType = contentTypeProperty == outMsgCtx.getProperty(JMSConstants.MESSAGE_TYPE) ? null
                 : JMSUtils.getProperty(message, contentTypeProperty);
 
         try {

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -622,7 +622,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         // load any transport headers from received message
         JMSUtils.loadTransportHeaders(message, responseMsgCtx);
 
-        String contentType = contentTypeProperty == null ? null
+        String contentType = contentTypeProperty == outMsgCtx.getProperty(JMSConstants.CONTENT_TYPE) ? null
                 : JMSUtils.getProperty(message, contentTypeProperty);
 
         try {


### PR DESCRIPTION
## Purpose
When receiving messages from IBM-MQ through a JMS proxy the Content-Type the header is getting removed. This causes to understand the message as a plain/text. Because of this, the response message is wrapped around a CDATA tag. The commit resolves this issue.