### PR TITLE
Fix wso2/product-ei#2776

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -333,6 +333,11 @@ public class JMSConstants {
       * */
      public static final String QUEUE_PREFIX = "queue.";
 
+    /**
+     *  The content type of a receiving payload
+     */
+     public static final String CONTENT_TYPE = "ContentType";
+
      /**
       * Andes Naming Factory
       * */

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -632,7 +632,7 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         // load any transport headers from received message
         JMSUtils.loadTransportHeaders(message, responseMsgCtx);
 
-        String contentType = contentTypeProperty == null ? null
+        String contentType = (contentTypeProperty == null) ? (String) outMsgCtx.getProperty(JMSConstants.CONTENT_TYPE)
                 : JMSUtils.getProperty(message, contentTypeProperty);
 
         try {


### PR DESCRIPTION
## Purpose
> When receiving messages from brokers that do not support headers with hyphens, through a JMS proxy, the Content-Type header gets removed. Due to this the message is treated as plain/text. As a result the response message gets wrapped around CDATA tags. 

This PR resolves https://github.com/wso2/product-ei/issues/2776.

## Goals
> To prevent the wrapping of response messages inside CDATA tags, when brokers that do not support headers with hyphens are used.