### PR TITLE
Fix EI server inconsistent state when rabbitmq server restarted

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
@@ -395,7 +395,7 @@ public class RabbitMQConnectionFactory {
 
     public DualChannel getRPCChannel() throws InterruptedException {
         try {
-            //creating a dual channel for each message
+            //creating a new connection for each message
             Connection connection = this.createConnection();
             Channel channel = connection.createChannel();
             QueueingConsumer consumer = new QueueingConsumer(channel);

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
@@ -419,6 +419,15 @@ public class RabbitMQConnectionFactory {
         return retryCount;
     }
 
+    public DualChannelPool getDualChannelPool() {
+        return dualChannelPool;
+    }
+
+    public void resetDualChannelPool() {
+        dualChannelPool.clear();
+        dualChannelPool = null;
+    }
+
     /**
      * Stop all the connections in this connection factory
      * Stop the executor service

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
@@ -88,6 +88,8 @@ public class RabbitMQRPCMessageSender {
         RabbitMQMessage responseMessage = processResponse(message.getCorrelationId());
         //removing the temporary queue after consuming the message
         dualChannel.getChannel().queueDelete(dualChannel.getReplyToQueue());
+        //closing the channel and connection
+        dualChannel.closeConnection();
 
         return responseMessage;
     }

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
@@ -274,7 +274,11 @@ public class RabbitMQRPCMessageSender {
 
         if (queueAutoDeclare && !RabbitMQUtils.isQueueAvailable(dualChannel.getChannel(), replyToQueue)) {
             log.info("Reply-to queue : " + replyToQueue + " not available, hence creating a new one");
-            RabbitMQUtils.declareQueue(dualChannel, replyToQueue, epProperties);
+            DualChannelPool dualChannelPool = connectionFactory.getDualChannelPool();
+            if (dualChannelPool != null) {
+                connectionFactory.resetDualChannelPool();
+                throw new AxisRabbitMQException("Connection pool is expired.");
+            }
         }
 
         int timeout = RabbitMQConstants.DEFAULT_REPLY_TO_TIMEOUT;

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
@@ -68,7 +68,6 @@ public class RabbitMQRPCMessageSender {
 
         this.targetEPR = targetEPR;
         this.connectionFactory = connectionFactory;
-
         try {
             dualChannel = connectionFactory.getRPCChannel();
         } catch (InterruptedException e) {
@@ -87,13 +86,8 @@ public class RabbitMQRPCMessageSender {
 
         publish(message, msgContext);
         RabbitMQMessage responseMessage = processResponse(message.getCorrelationId());
-
-        //release the dual channel to the pool
-        try {
-            connectionFactory.pushRPCChannel(dualChannel);
-        } catch (InterruptedException e) {
-            handleException(e.getMessage());
-        }
+        //removing the temporary queue after consuming the message
+        dualChannel.getChannel().queueDelete(dualChannel.getReplyToQueue());
 
         return responseMessage;
     }
@@ -274,10 +268,12 @@ public class RabbitMQRPCMessageSender {
 
         if (queueAutoDeclare && !RabbitMQUtils.isQueueAvailable(dualChannel.getChannel(), replyToQueue)) {
             log.info("Reply-to queue : " + replyToQueue + " not available, hence creating a new one");
-            DualChannelPool dualChannelPool = connectionFactory.getDualChannelPool();
-            if (dualChannelPool != null) {
-                connectionFactory.resetDualChannelPool();
-                throw new AxisRabbitMQException("Connection pool is expired.");
+            try {
+                dualChannel = connectionFactory.getRPCChannel();
+                consumer = dualChannel.getConsumer();
+                replyToQueue = dualChannel.getReplyToQueue();
+            } catch (InterruptedException e) {
+                handleException("Error while getting RPC channel", e);
             }
         }
 


### PR DESCRIPTION
## Purpose
> This PR will fix the inconsistent state when rabbitmq server restarted. 

Fixes: https://github.com/wso2/product-ei/issues/4309

## Approach
> Dual channel pool becomes invalid for a scenario when the rabbitmq server restarted since the created temporary queues are deleted. Hence considering this, dual channel pool implementation is removed and for each RPC message, a dual channel pool is created and serves the request and after serving the request, the channel is removed. 
