### PR TITLE
JMS Throttling improvement for JMS Proxies

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -417,4 +417,16 @@ public class JMSConstants {
      * Qualified name for SecureVault aliases.
      */
     public static final QName ALIAS_QNAME = new QName("http://org.wso2.securevault/configuration", "secretAlias");
+
+    /** Is Throttling enabled or not*/
+    public static final String JMS_PROXY_THROTTLE_ENABLED = "jms.proxy.throttle.enabled";
+    /** Throttling mode specified */
+    public static final String JMS_PROXY_THROTTLE_MODE = "jms.proxy.throttle.mode";
+    /** Throttling limit of messages per minute */
+    public static final String JMS_PROXY_THROTTLE_PER_MIN = "jms.proxy.throttle.limitPerMinute";
+    /** Batch Throttling constant */
+    public static final String JMS_PROXY_BATCH_THROTTLE = "batch";
+    /** Fixed Interval Throttlinh constant */
+    public static final String JMS_PROXY_FIXED_INTERVAL_THROTTLE = "fixed-interval";
+
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -558,7 +558,7 @@ public class ServiceTaskManager {
 
                                     consumedMessageCountPerMin = consumedMessageCountPerMin + 1;
 
-                                    if (consumedMessageCountPerMin == throttleLimitPerMin) {
+                                    if (consumedMessageCountPerMin >= throttleLimitPerMin) {
                                         long consumptionDuration = System.currentTimeMillis() - consumptionStartedTime;
 
                                         if (consumptionDuration < DateUtils.MILLIS_PER_MINUTE) {
@@ -594,7 +594,7 @@ public class ServiceTaskManager {
                 log.error("Error receiving the message.", e);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                log.error("Error in sleeping with Fixed-Interval throttling", e);
+                log.error("Error in sleeping with " + throttleMode + " throttling", e);
             } finally {
                 log.info("JMS Polling server task stopped for service " + serviceName + " " + this);
                 if (log.isTraceEnabled()) {

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
@@ -132,6 +132,19 @@ public class ServiceTaskManagerFactory {
             stm.setReconnectionProgressionFactor(dValue);
         }
 
+        value = getOptionalIntProperty(JMSConstants.JMS_PROXY_THROTTLE_PER_MIN, svc, cf);
+        if (value != null) {
+            stm.setThrottleLimitPerMin(value);
+        }
+        Boolean bValue = getOptionalBooleanProperty(JMSConstants.JMS_PROXY_THROTTLE_ENABLED, svc, cf);
+        if (bValue != null) {
+            stm.setThrottlingEnabled(bValue);
+        }
+        String sValue = getOptionalStringProperty(JMSConstants.JMS_PROXY_THROTTLE_MODE, svc, cf);
+        if (sValue != null) {
+            stm.setThrottleMode(sValue);
+        }
+
         stm.setWorkerPool(workerPool);
 
         // remove processed properties from property bag


### PR DESCRIPTION
- jms.proxy.throttle.mode implemented
- supports 2 modes Batch and Fixed-Interval
- added default ThrottleLimitPerMin value to 60

**Related issue**
https://github.com/wso2/product-ei/issues/4661