### PR TITLE
Support RabbitMQ message priority for dual channel

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/rpc/RabbitMQRPCMessageSender.java
@@ -365,6 +365,7 @@ public class RabbitMQRPCMessageSender {
         builder.replyTo(message.getReplyTo());
         builder.correlationId(message.getCorrelationId());
         builder.contentEncoding(message.getContentEncoding());
+        builder.priority(message.getPriority());
         Map<String, Object> headers = message.getHeaders();
         if (message.getSoapAction() != null) {
             headers.put(RabbitMQConstants.SOAP_ACTION, message.getSoapAction());


### PR DESCRIPTION
## Purpose
This PR will support RabbitMQ message priority for dual channel.

Fixes: wso2/product-ei#4083
Related to: wso2/wso2-axis2-transports#231

