### PR TITLE
Fix[EI-4795] JMS transport session recover upon mediation failure

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -407,6 +407,10 @@ public class JMSConstants {
 
     public static final String JMS_MESSAGE_DELIVERY_COUNT_HEADER = "JMSXDeliveryCount";
 
+    /**
+     * Message context level property indicating if JMS session need to be recovered associated with the message
+     */
+    public static final String SET_RECOVER = "SET_RECOVER";
 
     /**
      * Parameter for jndi security credentials in jms configs of axis2.xml

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageReceiver.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageReceiver.java
@@ -28,6 +28,7 @@ import javax.jms.*;
 import javax.transaction.UserTransaction;
 
 import static org.apache.axis2.transport.jms.JMSConstants.JMS_MESSAGE_DELIVERY_COUNT_HEADER;
+import static org.apache.axis2.transport.jms.JMSConstants.SET_RECOVER;
 
 /**
  * This is the JMS message receiver which is invoked when a message is received. This processes
@@ -217,13 +218,11 @@ public class JMSMessageReceiver {
                 soapAction,
                 contentTypeInfo.getContentType());
 
-        Object o = msgContext.getProperty(BaseConstants.SET_ROLLBACK_ONLY);
-        if (o != null) {
-            if ((o instanceof Boolean && ((Boolean) o)) ||
-                    (o instanceof String && Boolean.valueOf((String) o))) {
-                return false;
-            }
+        if (JMSUtils.checkIfBooleanPropertyIsSet(BaseConstants.SET_ROLLBACK_ONLY, msgContext)
+                || JMSUtils.checkIfBooleanPropertyIsSet(SET_RECOVER, msgContext)) {
+            return false;
         }
+
         return true;
     }
 

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -165,8 +165,8 @@ public class JMSMessageSender {
      */
     public void send(Message message, MessageContext msgCtx) throws JMSException {
 
-        jtaCommit = getBooleanProperty(msgCtx, BaseConstants.JTA_COMMIT_AFTER_SEND);
-        rollbackOnly = getBooleanProperty(msgCtx, BaseConstants.SET_ROLLBACK_ONLY);
+        jtaCommit = JMSUtils.checkIfBooleanPropertyIsSet(BaseConstants.JTA_COMMIT_AFTER_SEND, msgCtx);
+        rollbackOnly = JMSUtils.checkIfBooleanPropertyIsSet(BaseConstants.SET_ROLLBACK_ONLY, msgCtx);
         String deliveryMode = getStringProperty(msgCtx, JMSConstants.JMS_DELIVERY_MODE);
         Integer priority = getIntegerProperty(msgCtx, JMSConstants.JMS_PRIORITY);
         Integer timeToLive = getIntegerProperty(msgCtx, JMSConstants.JMS_TIME_TO_LIVE);

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
@@ -134,6 +134,25 @@ public class JMSUtils extends BaseUtils {
     }
 
     /**
+     * Check if a boolean property is set to the message context
+     *
+     * @param propertyName Name of the property
+     * @param msgContext   MessageContext instance
+     * @return True if property is set to true
+     */
+    static boolean checkIfBooleanPropertyIsSet(String propertyName, MessageContext msgContext) {
+        boolean isPropertySet = false;
+        Object booleanProperty = msgContext.getProperty(propertyName);
+        if (booleanProperty != null) {
+            if ((booleanProperty instanceof Boolean && ((Boolean) booleanProperty)) ||
+                    (booleanProperty instanceof String && Boolean.valueOf((String) booleanProperty))) {
+                isPropertySet = true;
+            }
+        }
+        return isPropertySet;
+    }
+
+    /**
      * Return the destination name from the given URL
      *
      * @param url the URL


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-ei/issues/4796

## Goals
Issue JMS session.recover() when mediation fails so that broker will resend the messages.  

## Approach
Set Axis2 level Synapse property `SET_RECOVER` in the fault sequence so that session will be recovered. To this to work, acknowledgement mode should be set to `CLIENT_ACK`. 

## Documentation
Need to add documentation

