### PR TITLE
Fix session.transacted not being honoured in JMS publisher

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageSender.java
@@ -165,8 +165,8 @@ public class JMSMessageSender {
      */
     public void send(Message message, MessageContext msgCtx) throws JMSException {
 
-        jtaCommit = JMSUtils.checkIfBooleanPropertyIsSet(BaseConstants.JTA_COMMIT_AFTER_SEND, msgCtx);
-        rollbackOnly = JMSUtils.checkIfBooleanPropertyIsSet(BaseConstants.SET_ROLLBACK_ONLY, msgCtx);
+        jtaCommit = getBooleanProperty(msgCtx, BaseConstants.JTA_COMMIT_AFTER_SEND);
+        rollbackOnly = getBooleanProperty(msgCtx, BaseConstants.SET_ROLLBACK_ONLY);
         String deliveryMode = getStringProperty(msgCtx, JMSConstants.JMS_DELIVERY_MODE);
         Integer priority = getIntegerProperty(msgCtx, JMSConstants.JMS_PRIORITY);
         Integer timeToLive = getIntegerProperty(msgCtx, JMSConstants.JMS_TIME_TO_LIVE);


### PR DESCRIPTION
## Purpose
This reverts the change done in https://github.com/wso2/wso2-axis2-transports/commit/a4a6021ed24f0a1f410013f706ab25241b876791 since it changed the behavior when JTA_COMMIT_AFTER_SEND was not set. This particular commit sets the value of jtaCommit to false, and hence session.transacted is not taken into account at a latter point.

Fixes the failures of JMSEndpointTestCase and JMSMapMessageTestCase