### PR TITLE
Release JMS session after the response received

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSReplyMessage.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSReplyMessage.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.axis2.transport.jms;
+
+import org.apache.axis2.context.MessageContext;
+
+import java.util.Map;
+
+import javax.jms.Destination;
+
+/**
+ * This class is used to hold the JMS response message information.
+ */
+public class JMSReplyMessage {
+
+    private MessageContext msgctx;
+    private Map<String, Object> transportHeaders;
+    private String soapAction;
+    private String contentType;
+    Destination replyDestination;
+
+    public Destination getReplyDestination() {
+
+        return replyDestination;
+    }
+
+    public void setReplyDestination(Destination replyDestination) {
+
+        this.replyDestination = replyDestination;
+    }
+
+    public MessageContext getMsgctx() {
+
+        return msgctx;
+    }
+
+    public void setMsgctx(MessageContext msgctx) {
+
+        this.msgctx = msgctx;
+    }
+
+    public Map<String, Object> getTransportHeaders() {
+
+        return transportHeaders;
+    }
+
+    public void setTransportHeaders(Map<String, Object> transportHeaders) {
+
+        this.transportHeaders = transportHeaders;
+    }
+
+    public String getSoapAction() {
+
+        return soapAction;
+    }
+
+    public void setSoapAction(String soapAction) {
+
+        this.soapAction = soapAction;
+    }
+
+    public String getContentType() {
+
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+
+        this.contentType = contentType;
+    }
+
+}

--- a/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
+++ b/modules/jms/src/test/java/org/apache/axis2/transport/jms/JMSSenderTestCase.java
@@ -89,13 +89,12 @@ public class JMSSenderTestCase extends TestCase {
         JMSOutTransportInfo jmsOutTransportInfo = Mockito.mock(JMSOutTransportInfo.class);
         JMSMessageSender jmsMessageSender = Mockito.mock(JMSMessageSender.class);
         Session session = Mockito.mock(Session.class);
-        Destination destination = Mockito.mock(Destination.class);
 
         Mockito.doReturn(session).when(jmsMessageSender).getSession();
         PowerMockito.whenNew(JMSOutTransportInfo.class).withArguments(any(String.class))
                 .thenReturn(jmsOutTransportInfo);
         Mockito.doReturn(jmsMessageSender).when(jmsOutTransportInfo).createJMSSender(any(MessageContext.class));
-        PowerMockito.doReturn(destination)
+        PowerMockito.doReturn(new JMSReplyMessage())
                 .when(jmsSender, "sendOverJMS", ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any(),
                         ArgumentMatchers.any(), ArgumentMatchers.any());
 
@@ -143,7 +142,6 @@ public class JMSSenderTestCase extends TestCase {
         JMSOutTransportInfo jmsOutTransportInfo = Mockito.mock(JMSOutTransportInfo.class);
         JMSMessageSender jmsMessageSender = Mockito.mock(JMSMessageSender.class);
         Session session = Mockito.mock(Session.class);
-        Destination destination = Mockito.mock(Destination.class);
 
         final String hyphenMode = "replace";
         JMSConnectionFactory jmsConnectionFactory = Mockito.mock(JMSConnectionFactory.class);
@@ -158,7 +156,7 @@ public class JMSSenderTestCase extends TestCase {
                     .thenReturn(jmsOutTransportInfo);
         Mockito.doReturn(jmsMessageSender).when(jmsOutTransportInfo).createJMSSender(any(MessageContext.class));
         PowerMockito.doReturn(jmsConnectionFactory).when(jmsSender, "getJMSConnectionFactory", ArgumentMatchers.any());
-        PowerMockito.doReturn(destination)
+        PowerMockito.doReturn(new JMSReplyMessage())
                     .when(jmsSender, "sendOverJMS", ArgumentMatchers.any(), ArgumentMatchers.any(),
                           ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any());
 


### PR DESCRIPTION
## Purpose
> Taking the response handling code out of the synchronized method so that
other threads don't have to wait until the complete message flow ends.
Fix wso2/product-ei/issues/5057