### PR TITLE
Fix: https://github.com/wso2/product-ei/issues/5047

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
@@ -30,7 +30,9 @@ import org.apache.axis2.format.DataSourceMessageBuilder;
 import org.apache.axis2.format.TextMessageBuilder;
 import org.apache.axis2.format.TextMessageBuilderAdapter;
 import org.apache.axis2.transport.TransportUtils;
+import org.apache.axis2.transport.base.BaseTransportException;
 import org.apache.axis2.transport.base.BaseUtils;
+import org.apache.axis2.transport.base.IgnoreSuspensionBaseTransportException;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageDataSource;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageInputStream;
 import org.apache.commons.logging.Log;
@@ -238,7 +240,14 @@ public class JMSUtils extends BaseUtils {
             documentElement = convertJMSMapToXML((MapMessage) message);
         }
         else {
-            handleException("Unsupported JMS message type " + message.getClass().getName());
+            try {
+                handleException("Unsupported JMS message type " + message.getClass().getName());
+            } catch (BaseTransportException e) {
+                //JMS transport receiving a malformed jms message should treated as a different case by introducing a
+                //Error code (101550) in Synapse level to differentiate this we have introduced a new Exception
+
+                throw new IgnoreSuspensionBaseTransportException(e.getMessage(), e);
+            }
             return; // Make compiler happy
         }
         msgContext.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));

--- a/pom.xml
+++ b/pom.xml
@@ -615,7 +615,7 @@
     </build>
     <properties>
         <axis2.transports.version>2.0.0-wso2v47-SNAPSHOT</axis2.transports.version>
-        <axis2.version>1.6.1-wso2v46</axis2.version>
+        <axis2.version>1.6.1-wso2v48</axis2.version>
         <carbon.kernel.version>4.5.3</carbon.kernel.version>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <imp.pkg.version.axiom>[1.2.11, 1.3.0)</imp.pkg.version.axiom>


### PR DESCRIPTION
## Purpose
The JMS endpoints in request-response service (JMS dual-channel proxy service )
will immediately suspend when it receives a malformed JMS message (The type which).
Fix this by introducing a new error_code 101550.

Fixes: https://github.com/wso2/product-ei/issues/5047