### PR TITLE
Create error context when an unsupported msg is received

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -433,4 +433,7 @@ public class JMSConstants {
     /** Fixed Interval Throttlinh constant */
     public static final String JMS_PROXY_FIXED_INTERVAL_THROTTLE = "fixed-interval";
 
+    // Error handling properties.
+    static final String SENDING_FAULT = "SENDING_FAULT";
+    static final String ERROR_MESSAGE = "ERROR_MESSAGE";
 }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
@@ -30,9 +30,7 @@ import org.apache.axis2.format.DataSourceMessageBuilder;
 import org.apache.axis2.format.TextMessageBuilder;
 import org.apache.axis2.format.TextMessageBuilderAdapter;
 import org.apache.axis2.transport.TransportUtils;
-import org.apache.axis2.transport.base.BaseTransportException;
 import org.apache.axis2.transport.base.BaseUtils;
-import org.apache.axis2.transport.base.IgnoreSuspensionBaseTransportException;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageDataSource;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageInputStream;
 import org.apache.commons.logging.Log;
@@ -240,14 +238,7 @@ public class JMSUtils extends BaseUtils {
             documentElement = convertJMSMapToXML((MapMessage) message);
         }
         else {
-            try {
-                handleException("Unsupported JMS message type " + message.getClass().getName());
-            } catch (BaseTransportException e) {
-                //JMS transport receiving a malformed jms message should treated as a different case by introducing a
-                //Error code (101550) in Synapse level to differentiate this we have introduced a new Exception
-
-                throw new IgnoreSuspensionBaseTransportException(e.getMessage(), e);
-            }
+            handleException("Unsupported JMS message type " + message.getClass().getName());
             return; // Make compiler happy
         }
         msgContext.setEnvelope(TransportUtils.createSOAPEnvelope(documentElement));


### PR DESCRIPTION
$subject. Since throwing exception leads to endpoint suspension and the endpoint suspension is not acceptable as the endpoint has already responded.

Fixes wso2/product-ei#5047