### PR TITLE
Preserve INTERNAL_TRANSACTION_COUNTED property in JMS transport

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageReceiver.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageReceiver.java
@@ -17,14 +17,18 @@ package org.apache.axis2.transport.jms;
 
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
+import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.MetricsCollector;
 import org.apache.axis2.transport.jms.ctype.ContentTypeInfo;
-import org.apache.axis2.context.MessageContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import javax.jms.*;
+import javax.jms.DeliveryMode;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
 import javax.transaction.UserTransaction;
 
 import static org.apache.axis2.transport.jms.JMSConstants.JMS_MESSAGE_DELIVERY_COUNT_HEADER;
@@ -211,6 +215,10 @@ public class JMSMessageReceiver {
         }
 
         msgContext.setProperty(JMSConstants.PARAM_JMS_HYPHEN_MODE, endpoint.getHyphenSupport());
+
+        // set "INTERNAL_TRANSACTION_COUNTED" property in the message context if is present in the JMS message received.
+        msgContext.setProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED,
+                               message.getBooleanProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED));
 
         jmsListener.handleIncomingMessage(
                 msgContext,

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSSender.java
@@ -619,6 +619,8 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         }
 
         JMSUtils.setTransportHeaders(msgContext, message);
+        // set INTERNAL_TRANSACTION_COUNTED property in the JMS message if it is present in the messageContext
+        setTransactionProperty(msgContext, message);
         return message;
     }
 
@@ -675,6 +677,24 @@ public class JMSSender extends AbstractTransportSender implements ManagementSupp
         jmsReplyMessage.setSoapAction(JMSUtils.getProperty(message, BaseConstants.SOAPACTION));
         jmsReplyMessage.setContentType(contentType);
         return jmsReplyMessage;
+    }
+
+    /**
+     * Set the "INTERNAL_TRANSACTION_COUNTED" property in the message if it is present in the message context.
+     *
+     * @param msgContext the message context.
+     * @param message the JMS message.
+     */
+    private void setTransactionProperty(MessageContext msgContext, Message message) {
+        Object transactionProperty = msgContext.getProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED);
+        if (transactionProperty instanceof Boolean) {
+            try {
+                message.setBooleanProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED, (Boolean) transactionProperty);
+            } catch (JMSException e) {
+                log.warn("Couldn't set message property : " + BaseConstants.INTERNAL_TRANSACTION_COUNTED + " = "
+                                 + transactionProperty, e);
+            }
+        }
     }
 
     private void setProperty(Message message, MessageContext msgCtx, String key) {

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSUtils.java
@@ -30,6 +30,7 @@ import org.apache.axis2.format.DataSourceMessageBuilder;
 import org.apache.axis2.format.TextMessageBuilder;
 import org.apache.axis2.format.TextMessageBuilderAdapter;
 import org.apache.axis2.transport.TransportUtils;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.BaseUtils;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageDataSource;
 import org.apache.axis2.transport.jms.iowrappers.BytesMessageInputStream;
@@ -602,7 +603,8 @@ public class JMSUtils extends BaseUtils {
                 } catch (JMSException ignore) {}
             }
         }
-
+        // remove "INTERNAL_TRANSACTION_COUNTED" header from the transport level headers map.
+        map.remove(BaseConstants.INTERNAL_TRANSACTION_COUNTED);
         return map;
     }
 


### PR DESCRIPTION
## Purpose
To track the transactions that involve the JMS transport (as part of the transaction counting mechanism), the message property called "INTERNAL_TRANSACTION_COUNTED" is maintained throughout the JMSSender and JMSMessageReceiver classes.

- JMSSender - When creating a JMS Message from the given MessageContext, the property is set in the JMS message if it is present in the MessageContext.
- JMSMessageReceiver - When a JMS message is received, if this property is present in the TRANSPORT_HEADERS, it will be moved to the messageContext getting created out of the JMS message. 

