### PR TITLE
Preserve INTERNAL_TRANSACTION_COUNTED in RabbitMQ

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
@@ -22,6 +22,7 @@ import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Delivery;
 import org.apache.axis2.context.MessageContext;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
@@ -32,6 +33,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -271,6 +273,11 @@ public class RabbitMQMessageSender {
         if (senderType == RabbitMQSender.SenderType.RPC) {
             builder.replyTo(channel.queueDeclare().getQueue());
             headers.put(RabbitMQConstants.RABBITMQ_CON_FAC, factoryName);
+        }
+
+        if (msgCtx.getProperties().containsKey(BaseConstants.INTERNAL_TRANSACTION_COUNTED)) {
+            headers.put(BaseConstants.INTERNAL_TRANSACTION_COUNTED,
+                        msgCtx.getProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED));
         }
 
         builder.headers(headers);


### PR DESCRIPTION
## Purpose
Preserves the INTERNAL_TRANSACTION_COUNTED property in RabbitMQ transport and inbound so that a transaction that is made asynchronous using RabbitMQ broker is not counted as 2.

Resolves: https://github.com/wso2/micro-integrator/issues/1649 for the inbound and the transport