### PR TITLE
Throw fault for no response

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
@@ -21,6 +21,7 @@ package org.apache.axis2.transport.rabbitmq;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Delivery;
+import org.apache.axis2.AxisFault;
 import org.apache.axis2.context.MessageContext;
 import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.commons.lang.StringUtils;
@@ -144,7 +145,7 @@ public class RabbitMQMessageSender {
             channel.basicCancel(replyConsumerTag);
         }
         if (response == null) {
-            log.warn("Did not receive a response within " + timeout + "ms to the replyTo queue " + replyTo);
+            throw new AxisFault("Did not receive a response within " + timeout + "ms to the replyTo queue " + replyTo);
         }
         return response;
     }

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQSender.java
@@ -130,6 +130,9 @@ public class RabbitMQSender extends AbstractTransportSender {
                 }
                 RabbitMQMessageSender sender = new RabbitMQMessageSender(channel, factoryName, senderType);
                 response = sender.send(routingKey, msgCtx, epProperties);
+            } catch (AxisFault e) {
+                channel = null;
+                handleException("Error occurred while sending message out.", e);
             } catch (Exception e) {
                 log.error("Error occurred while sending message out.", e);
                 channel = null;

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
@@ -56,6 +56,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -448,7 +449,8 @@ public class RabbitMQUtils {
         msgContext.setProperty(Constants.Configuration.CHARACTER_SET_ENCODING, charSetEnc);
 
         // set "INTERNAL_TRANSACTION_COUNTED" property in the message context if is present in the JMS message received.
-        if (properties.getHeaders().containsKey(BaseConstants.INTERNAL_TRANSACTION_COUNTED)) {
+        Map<String, Object> headers = properties.getHeaders();
+        if (Objects.nonNull(headers) && headers.containsKey(BaseConstants.INTERNAL_TRANSACTION_COUNTED)) {
             msgContext.setProperty(BaseConstants.INTERNAL_TRANSACTION_COUNTED,
                                    properties.getHeaders().get(BaseConstants.INTERNAL_TRANSACTION_COUNTED));
         }


### PR DESCRIPTION
## Purpose
Throws an axis fault when a response is not received to the reply queue in a dual channel scenario.