### PR TITLE
Fix race condition which leads to test failure

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -239,7 +239,7 @@ public class ServiceTaskManager {
                     " for service : " + serviceName);
             }
         }
-
+        serviceTaskManagerState = STATE_STARTED;
         for (int i=0; i<concurrentConsumers; i++) {
             if (jmsMessageReceiver.getJmsListener().getState() == BaseConstants.PAUSED) {
                 workerPool.execute(new MessageListenerTask(BaseConstants.PAUSED));
@@ -247,8 +247,6 @@ public class ServiceTaskManager {
                 workerPool.execute(new MessageListenerTask(BaseConstants.STARTED));
             }
         }
-
-        serviceTaskManagerState = STATE_STARTED;
         log.info("Task manager for service : " + serviceName + " [re-]initialized");
 
     }


### PR DESCRIPTION
## Purpose
Fix intermittent failure of MinConcurrencyTest after https://github.com/wso2/wso2-axis2-transports/pull/278

## Goals
The state of ServiceTaskManager is set to started only after scheduling the MessageListeners. The message listener checks for the state of the ServiceTaskManager and immediately terminate if it is not in the started state. Therefore, when multiple listeners are being scheduled, the first few tasks will still see that the active state is false and terminate its execution bringing down the concurrent nature of the ServiceTaskManager.