### PR TITLE
Apply content.type from proxy parameter

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
@@ -70,8 +70,15 @@ public class RabbitMQMessageReceiver {
      * @throws AxisFault on Axis2 errors
      */
     private AcknowledgementMode processThroughAxisEngine(AMQP.BasicProperties properties, byte[] body) throws AxisFault {
-
         MessageContext msgContext = endpoint.createMessageContext();
+        // Get transport properties for configured contentType
+        String contentTypeParameter = null;
+        try {
+            contentTypeParameter = endpoint.getServiceTaskManager().getRabbitMQProperties().get(RabbitMQConstants.CONTENT_TYPE);
+            msgContext.setProperty(RabbitMQConstants.CONTENT_TYPE, contentTypeParameter);
+        } catch(Exception e)    {
+            log.warn("Error while getting content-type from proxy", e);
+        }
         String contentType = RabbitMQUtils.buildMessageWithReplyTo(properties, body, msgContext);
         try {
             listener.handleIncomingMessage(

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
@@ -414,12 +414,20 @@ public class RabbitMQUtils {
             msgContext.setProperty(RabbitMQConstants.CORRELATION_ID, amqpCorrelationID);
         } else {
             msgContext.setProperty(RabbitMQConstants.CORRELATION_ID, properties.getMessageId());
-        }
+        }        
         // set content-type to the message context
-        String contentType = properties.getContentType();
+        String contentType = null;
+        // keep content-type if already configured
+        Object contentTypeFromMC = msgContext.getProperty(RabbitMQConstants.CONTENT_TYPE);
+        if(contentTypeFromMC != null && contentTypeFromMC instanceof String) {
+            contentType = (String) contentTypeFromMC;
+        }
+        if (contentType == null || contentType.isEmpty()) {
+            contentType = properties.getContentType();
+        }
         if (contentType == null) {
             log.warn("Unable to determine content type for message " + msgContext.getMessageID()
-                     + " setting to text/plain");
+                     + " setting to " + RabbitMQConstants.DEFAULT_CONTENT_TYPE);
             contentType = RabbitMQConstants.DEFAULT_CONTENT_TYPE;
         }
         msgContext.setProperty(RabbitMQConstants.CONTENT_TYPE, contentType);


### PR DESCRIPTION
## Purpose
This fixes the missing feature with the new rabbitmq transport build for MicroIntegrator 1.2.0. It was not anymore possible to specify the expected content-type in a proxy. 
This missing feature is a message leak which must be fixed. Because when a message in rabbitmq is not compatible with text/plain, the message would be lost. 

## Goals
The parameter inside the proxy is added to the messageContext first. If the parameter is not present, the behaviour stays the same.

## Approach
n/a

## User stories
n/a

## Release note
rabbitmq.message.content.type | The content type of the consumer. Note: If the content type is specified in the message, this parameter does override the specified content type of the message. Otherwise the default value is text/xml.


## Documentation
Here the documentation must be adapted and write that the content-type is taken into consideration: 

https://ei.docs.wso2.com/en/7.2.0/micro-integrator/references/synapse-properties/transport-parameters/rabbitmq-transport-parameters/#other-parameters-optional

## Training
n/a

## Certification
n/a

## Marketing
none

## Automation tests
none

## Security checks
none

## Related PRs
none

## Migrations (if applicable)
not necessary

## Test environment
OpenJDK 8, Micro Integrator 1.2.0
 
## Learning
n/a