### PR TITLE
Update TCPServer.java

### DIFF
--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPServer.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPServer.java
@@ -57,6 +57,11 @@ public class TCPServer implements Runnable {
             }
 
             if (socket != null) {
+                //enabling the boolean value true
+                // TODO make this option configurable over proxy params
+                boolean on=true;
+                //setKeepAlive() method either enables or disables the SO_KEEPALIVE option
+                socket.setKeepAlive(on);
                 workerPool.execute(new TCPWorker(endpoint, socket));
             }
         }

--- a/modules/tcp/src/org/apache/axis2/transport/tcp/TCPServer.java
+++ b/modules/tcp/src/org/apache/axis2/transport/tcp/TCPServer.java
@@ -49,6 +49,11 @@ public class TCPServer implements Runnable {
 
             try {
                 socket = serverSocket.accept();
+                //enabling the boolean value true
+                // TODO make this option configurable over proxy params
+                boolean on=true;
+                //setKeepAlive() method either enables or disables the SO_KEEPALIVE option
+                socket.setKeepAlive(on);
             } catch (java.io.InterruptedIOException ignored) {
 
             } catch (Exception e) {
@@ -57,11 +62,6 @@ public class TCPServer implements Runnable {
             }
 
             if (socket != null) {
-                //enabling the boolean value true
-                // TODO make this option configurable over proxy params
-                boolean on=true;
-                //setKeepAlive() method either enables or disables the SO_KEEPALIVE option
-                socket.setKeepAlive(on);
                 workerPool.execute(new TCPWorker(endpoint, socket));
             }
         }


### PR DESCRIPTION
Set keepalive for TCP server

## Purpose
There are no way to enable / disable TCP keepalive option for wso2 tcp listeners. This caused that wso2 leaves invalid TCP connections in ESTABLISHED state forever. Therefore I strongly propose use setKeepAlive() for Socket object in TCPServer.java before creating new TCP worker. 

## Goals
Fix invalid open connections.