### PR TITLE
Set the JMS Message ID as Message Context ID only if JMS Message ID is not

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageReceiver.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSMessageReceiver.java
@@ -160,9 +160,11 @@ public class JMSMessageReceiver {
 
         MessageContext msgContext = endpoint.createMessageContext();
 
-        // set the JMS Message ID as the Message ID of the MessageContext
+        // set the JMS Message ID as the Message ID of the MessageContext if JMS Message ID is not null
         try {
-            msgContext.setMessageID(message.getJMSMessageID());
+            if (message.getJMSMessageID() != null) {
+                msgContext.setMessageID(message.getJMSMessageID());
+            }
             String jmsCorrelationID = message.getJMSCorrelationID();
             if (jmsCorrelationID != null && jmsCorrelationID.length() > 0) {
                 msgContext.setProperty(JMSConstants.JMS_COORELATION_ID, jmsCorrelationID);

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailTransportListener.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailTransportListener.java
@@ -494,8 +494,10 @@ public class MailTransportListener extends AbstractPollingTransportListener<Poll
                     outInfo.getFromAddress().getAddress()));
         }
 
-        // save original mail message id message context MessageID
-        msgContext.setMessageID(outInfo.getRequestMessageID());
+        // set the Mail Message ID as the Message ID of the MessageContext if Mail Message ID is not null
+        if (outInfo.getRequestMessageID() != null) {
+            msgContext.setMessageID(outInfo.getRequestMessageID());
+        }
 
         // set the message payload to the message context
         InputStream in = messagePart.getInputStream();


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/micro-integrator/issues/2225

## Goals
When a message received from a JMS listener is passed to an OAuth configured HTTP endpoint, an NPE was thrown. This was happening because JMS Message ID was null when receiving the message from the queue and this ID was set as the message context ID. With this fix, we only assign the JMS message ID as message context ID only if it's not null.

## Approach
- Set the JMS Message ID as Message Context ID only if JMS Message ID is not
- Set the Mail Message ID as Message Context ID only if Mail Message ID is not