### PR TITLE
Add jms throttling granularity and externalize throttle count parameter

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSConstants.java
@@ -428,6 +428,21 @@ public class JMSConstants {
     public static final String JMS_PROXY_THROTTLE_MODE = "jms.proxy.throttle.mode";
     /** Throttling limit of messages per minute */
     public static final String JMS_PROXY_THROTTLE_PER_MIN = "jms.proxy.throttle.limitPerMinute";
+    /** Time unit to be used for throttling i.e: minute, day, hour */
+    public static final String JMS_PROXY_THROTTLE_TIME_UNIT = "jms.proxy.throttle.timeUnit";
+    /** Number of messages to trigger throttling in a unit time unit */
+    public static final String JMS_PROXY_THROTTLE_COUNT = "jms.proxy.throttle.count";
+    /** Is throttle count read dynamically. True leads to low performance */
+    public static final String JMS_PROXY_DYNAMIC_THROTTLE_ENABLED = "jms.proxy.throttle.dynamic.enabled";
+    /** System property to be set if the dynamic throttling is enabled */
+    public static final String JMS_PROXY_DYNAMIC_THROTTLE_PROPERTY = "jms.proxy.throttle.count.systemProperty";
+
+    public static final String JMS_PROXY_THROTTLE_HOUR = "hour";
+
+    public static final String JMS_PROXY_THROTTLE_MINUTE = "minute";
+
+    public static final String JMS_PROXY_THROTTLE_DAY = "day";
+
     /** Batch Throttling constant */
     public static final String JMS_PROXY_BATCH_THROTTLE = "batch";
     /** Fixed Interval Throttlinh constant */

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManagerFactory.java
@@ -124,7 +124,7 @@ public class ServiceTaskManagerFactory {
             stm.setInitialReconnectDuration(value);
         }
         value = getOptionalIntProperty(JMSConstants.PARAM_RECON_MAX_DURATION, svc, cf);
-        if (value != null) {
+        if (value != null) {value = getOptionalIntProperty(JMSConstants.JMS_PROXY_THROTTLE_PER_MIN, svc, cf);
             stm.setMaxReconnectDuration(value);
         }
         Double dValue = getOptionalDoubleProperty(JMSConstants.PARAM_RECON_FACTOR, svc, cf);
@@ -136,13 +136,35 @@ public class ServiceTaskManagerFactory {
         if (value != null) {
             stm.setThrottleLimitPerMin(value);
         }
+
+        value = getOptionalIntProperty(JMSConstants.JMS_PROXY_THROTTLE_COUNT, svc, cf);
+        if (value != null) {
+            stm.setThrottleCount(value);
+        }
+
         Boolean bValue = getOptionalBooleanProperty(JMSConstants.JMS_PROXY_THROTTLE_ENABLED, svc, cf);
         if (bValue != null) {
             stm.setThrottlingEnabled(bValue);
         }
+
+        bValue = getOptionalBooleanProperty(JMSConstants.JMS_PROXY_DYNAMIC_THROTTLE_ENABLED, svc, cf);
+        if (bValue != null) {
+            stm.setDynamicThrottlingEnabled(bValue);
+        }
+
         String sValue = getOptionalStringProperty(JMSConstants.JMS_PROXY_THROTTLE_MODE, svc, cf);
         if (sValue != null) {
             stm.setThrottleMode(sValue);
+        }
+
+        sValue = getOptionalStringProperty(JMSConstants.JMS_PROXY_THROTTLE_TIME_UNIT, svc, cf);
+        if (sValue != null) {
+            stm.setThrottleTimeUnit(sValue);
+        }
+
+        sValue = getOptionalStringProperty(JMSConstants.JMS_PROXY_DYNAMIC_THROTTLE_PROPERTY, svc, cf);
+        if (sValue != null) {
+            stm.setDynamicThrottlePropertyName(sValue);
         }
 
         stm.setWorkerPool(workerPool);


### PR DESCRIPTION
## Purpose
> $subject

- jms.proxy.throttle.count.systemProperty - Name of the system property which can be used to set the throttle count for the consumer
```
<proxy xmlns="http://ws.apache.org/ns/synapse" name="jmsProxy" transports="jms">
      <target>
          <inSequence>
             <log level="full"/>
             <drop/>
          </inSequence>
          <outSequence/>
      </target>
      <parameter name="transport.jms.ContentType">
          <rules>
              <jmsProperty>contentType</jmsProperty>
              <default>application/json</default>
          </rules>
      </parameter>
    <parameter name="transport.jms.Destination">throttledQueue</parameter>
    <parameter name="transport.jms.ConnectionFactory">myQueueConnectionFactory</parameter>
    <parameter name="jms.proxy.throttle.enabled">true</parameter>
    <parameter name="jms.proxy.throttle.mode">batch</parameter>
    <parameter name="jms.proxy.throttle.timeUnit">minute</parameter>
    <parameter name="jms.proxy.throttle.count">4</parameter>
    <parameter name="jms.proxy.throttle.count.systemProperty">jmsProxyThrottleCount</parameter>
    <parameter name="jms.proxy.throttle.dynamic.enabled">true</parameter>
  </proxy>
```

Fix: https://github.com/wso2/micro-integrator/issues/2349