### PR TITLE
Fix the issue of exchange auto declaration failure due to inequivalent args

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -115,6 +115,8 @@ public class RabbitMQConstants {
     public static final String EXCHANGE_DURABLE_DEFAULT = "true";
     public static final String QUEUE_DURABLE_DEFAULT = "true";
 
+    public static final String IN_EQUIVALENT_ARGUMENT_ERROR = "inequivalent arg";
+    public static final String QUEUE = "queue";
+    public static final String EXCHANGE = "exchange";
+
 }
-
-

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
@@ -49,18 +49,26 @@ public class RabbitMQMessageSender {
     private Channel channel;
     private String factoryName;
     private RabbitMQSender.SenderType senderType;
+    private final RabbitMQChannelPool rabbitMQChannelPool;
+    private final RabbitMQChannelPool rabbitMQConfirmChannelPool;
 
     /**
-     * Create a RabbitMQSender using a ConnectionFactory and target EPR
+     * Create a RabbitMQSender using a ConnectionFactory and target EPR.
      *
-     * @param channel     the {@link Channel} object
-     * @param factoryName the connection factory name
-     * @param senderType  the type of the sender to execute the different logic
+     * @param channel                    the {@link Channel} object
+     * @param factoryName                the connection factory name
+     * @param senderType                 the type of the sender to execute the different logic
+     * @param rabbitMQChannelPool        rabbitmq channel  pool
+     * @param rabbitMQConfirmChannelPool rabbitmq confirm channel  pool
      */
-    public RabbitMQMessageSender(Channel channel, String factoryName, RabbitMQSender.SenderType senderType) {
+    public RabbitMQMessageSender(Channel channel, String factoryName, RabbitMQSender.SenderType senderType,
+                                 RabbitMQChannelPool rabbitMQChannelPool,
+                                 RabbitMQChannelPool rabbitMQConfirmChannelPool) {
         this.channel = channel;
         this.senderType = senderType;
         this.factoryName = factoryName;
+        this.rabbitMQChannelPool = rabbitMQChannelPool;
+        this.rabbitMQConfirmChannelPool = rabbitMQConfirmChannelPool;
     }
 
     /**
@@ -75,15 +83,25 @@ public class RabbitMQMessageSender {
      * @throws InterruptedException
      */
     // TODO: handle x-consistent-hash
-    public Delivery send(String routingKey, MessageContext msgContext, Map<String, String> rabbitMQProperties)
-            throws IOException, AxisRabbitMQException {
+    public Delivery send(String routingKey, MessageContext msgContext,
+                         Map<String, String> rabbitMQProperties) throws Exception {
+
         Delivery response = null;
-
-
         // declaring queue if given
         String queueName = rabbitMQProperties.get(RabbitMQConstants.QUEUE_NAME);
         String exchangeName = rabbitMQProperties.get(RabbitMQConstants.EXCHANGE_NAME);
-        RabbitMQUtils.declareQueuesExchangesAndBindings(channel, queueName, exchangeName, rabbitMQProperties);
+
+        try {
+            RabbitMQUtils.declareQueue(channel, queueName, rabbitMQProperties);
+        } catch (IOException ex) {
+            checkAndIgnoreInEquivalentParamException(ex, RabbitMQConstants.QUEUE, queueName);
+        }
+        try {
+            RabbitMQUtils.declareExchange(channel, exchangeName, rabbitMQProperties);
+        } catch (IOException ex) {
+            checkAndIgnoreInEquivalentParamException(ex, RabbitMQConstants.EXCHANGE, exchangeName);
+        }
+        RabbitMQUtils.bindQueueToExchange(channel, queueName, exchangeName, rabbitMQProperties);
 
         AMQP.BasicProperties.Builder builder = buildBasicProperties(msgContext);
 
@@ -113,6 +131,25 @@ public class RabbitMQMessageSender {
         }
 
         return response;
+    }
+
+    private void checkAndIgnoreInEquivalentParamException(IOException ex, String entity,
+                                                          String queueOrExchangeName) throws Exception {
+
+        String cause = ex.getCause() != null ? ex.getCause().getMessage() : null;
+        if (cause != null && cause.contains(RabbitMQConstants.IN_EQUIVALENT_ARGUMENT_ERROR)) {
+            // borrowing a new channel as the existing one is closed due to exception
+            if (senderType == RabbitMQSender.SenderType.PUBLISHER_CONFIRMS) {
+                channel = rabbitMQConfirmChannelPool.borrowObject(factoryName);
+            } else {
+                channel = rabbitMQChannelPool.borrowObject(factoryName);
+            }
+            log.info("Declaration failed for " + entity + " named " + queueOrExchangeName
+                    + " due to in equivalent arguments. Using the existing one.");
+            log.debug(ex);
+        } else {
+            throw ex;
+        }
     }
 
     /**

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
@@ -145,9 +145,11 @@ public class RabbitMQMessageSender {
             } else {
                 newChannel = rabbitMQChannelPool.borrowObject(factoryName);
             }
-            log.info("Declaration failed for " + entity + " named " + queueOrExchangeName
-                    + " due to in equivalent arguments. Using the existing one.");
-            log.debug(ex);
+            if (log.isDebugEnabled()) {
+                log.debug("Declaration failed for " + entity + " named " + queueOrExchangeName
+                        + " due to in equivalent arguments. Using the existing one.");
+                log.debug(ex);
+            }
             return newChannel;
         } else {
             throw ex;

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQSender.java
@@ -128,7 +128,8 @@ public class RabbitMQSender extends AbstractTransportSender {
                 } else {
                     channel = rabbitMQChannelPool.borrowObject(factoryName);
                 }
-                RabbitMQMessageSender sender = new RabbitMQMessageSender(channel, factoryName, senderType);
+                RabbitMQMessageSender sender = new RabbitMQMessageSender(channel, factoryName, senderType,
+                        rabbitMQChannelPool, rabbitMQConfirmChannelPool);
                 response = sender.send(routingKey, msgCtx, epProperties);
             } catch (Exception e) {
                 channel = null;
@@ -165,7 +166,8 @@ public class RabbitMQSender extends AbstractTransportSender {
 
                 // send the message to the replyTo queue
                 channel = rabbitMQChannelPool.borrowObject(factoryName);
-                RabbitMQMessageSender sender = new RabbitMQMessageSender(channel, factoryName, SenderType.DEFAULT);
+                RabbitMQMessageSender sender = new RabbitMQMessageSender(channel, factoryName, SenderType.DEFAULT,
+                        rabbitMQChannelPool, rabbitMQConfirmChannelPool);
                 sender.send(replyTo, msgCtx, rabbitMQProperties);
             } catch (Exception e) {
                 log.error("Error occurred while sending message out.", e);

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
@@ -244,9 +244,11 @@ public class RabbitMQUtils {
         if (cause != null && cause.contains(RabbitMQConstants.IN_EQUIVALENT_ARGUMENT_ERROR)) {
             // creating a new channel as the existing one is closed due to exception
             Channel newChannel = connection.createChannel();
-            log.info("Declaration failed for " + entity + " named " + queueOrExchangeName
-                    + " due to in equivalent arguments. Using the existing one.");
-            log.debug(ex);
+            if (log.isDebugEnabled()) {
+                log.debug("Declaration failed for " + entity + " named " + queueOrExchangeName
+                        + " due to in equivalent arguments. Using the existing one.");
+                log.debug(ex);
+            }
             ((com.rabbitmq.client.Recoverable) newChannel).addRecoveryListener(new RabbitMQRecoveryListener());
             return newChannel;
         } else {

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
@@ -231,11 +231,27 @@ public class RabbitMQUtils {
      * @throws IOException if any error occurs during the declaration/binding
      */
     public static void declareQueuesExchangesAndBindings(Channel channel, String queueName, String exchangeName,
-            Map<String, String> properties) throws IOException {
+                                                         Map<String, String> properties) throws IOException {
 
         declareQueue(channel, queueName, properties);
         declareExchange(channel, exchangeName, properties);
         bindQueueToExchange(channel, queueName, exchangeName, properties);
+    }
+
+    public static Channel checkAndIgnoreInEquivalentParamException(Connection connection, IOException ex, String entity,
+                                                            String queueOrExchangeName) throws IOException {
+        String cause = ex.getCause() != null ? ex.getCause().getMessage() : null;
+        if (cause != null && cause.contains(RabbitMQConstants.IN_EQUIVALENT_ARGUMENT_ERROR)) {
+            // creating a new channel as the existing one is closed due to exception
+            Channel newChannel = connection.createChannel();
+            log.info("Declaration failed for " + entity + " named " + queueOrExchangeName
+                    + " due to in equivalent arguments. Using the existing one.");
+            log.debug(ex);
+            ((com.rabbitmq.client.Recoverable) newChannel).addRecoveryListener(new RabbitMQRecoveryListener());
+            return newChannel;
+        } else {
+            throw ex;
+        }
     }
 
     /**
@@ -246,7 +262,7 @@ public class RabbitMQUtils {
      * @param properties queue declaration properties
      * @throws IOException
      */
-    private static void declareQueue(Channel channel, String queueName,
+    public static void declareQueue(Channel channel, String queueName,
                                     Map<String, String> properties) throws IOException {
         boolean autoDeclare = BooleanUtils.toBooleanDefaultIfNull(
                 BooleanUtils.toBooleanObject(properties.get(RabbitMQConstants.QUEUE_AUTODECLARE)), true);
@@ -263,7 +279,7 @@ public class RabbitMQUtils {
      * @param exchangeName the exchange exchangeName
      * @param properties   RabbitMQ properties
      */
-    private static void declareExchange(Channel channel, String exchangeName, Map<String, String> properties) throws IOException {
+    public static void declareExchange(Channel channel, String exchangeName, Map<String, String> properties) throws IOException {
         boolean autoDeclare = BooleanUtils.toBooleanDefaultIfNull(
                 BooleanUtils.toBooleanObject(properties.get(RabbitMQConstants.EXCHANGE_AUTODECLARE)), true);
         if (StringUtils.isNotEmpty(exchangeName) && autoDeclare && !exchangeName.startsWith(RabbitMQConstants.AMQ_PREFIX)) {
@@ -284,7 +300,7 @@ public class RabbitMQUtils {
      * @param properties   optional RabbitMQ properties for the binding creation
      * @throws IOException if an error occurs while creating the binding
      */
-    private static void bindQueueToExchange(Channel channel, String queueName, String exchangeName,
+    public static void bindQueueToExchange(Channel channel, String queueName, String exchangeName,
             Map<String, String> properties) throws IOException {
         if (StringUtils.isNotEmpty(exchangeName)) {
             String routingKey = properties.get(RabbitMQConstants.QUEUE_ROUTING_KEY);

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/ServiceTaskManager.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/ServiceTaskManager.java
@@ -109,7 +109,20 @@ public class ServiceTaskManager {
             // declaring queue
             queueName = rabbitMQProperties.get(RabbitMQConstants.QUEUE_NAME);
             String exchangeName = rabbitMQProperties.get(RabbitMQConstants.EXCHANGE_NAME);
-            RabbitMQUtils.declareQueuesExchangesAndBindings(channel, queueName, exchangeName, rabbitMQProperties);
+
+            try {
+                RabbitMQUtils.declareQueue(channel, queueName, rabbitMQProperties);
+            } catch (IOException ex) {
+                channel = RabbitMQUtils.checkAndIgnoreInEquivalentParamException(connection, ex,
+                        RabbitMQConstants.QUEUE, queueName);
+            }
+            try {
+                RabbitMQUtils.declareExchange(channel, exchangeName, rabbitMQProperties);
+            } catch (IOException ex) {
+                channel = RabbitMQUtils.checkAndIgnoreInEquivalentParamException(connection, ex,
+                        RabbitMQConstants.EXCHANGE, exchangeName);
+            }
+            RabbitMQUtils.bindQueueToExchange(channel, queueName, exchangeName, rabbitMQProperties);
 
             // get max dead-lettered count
             maxDeadLetteredCount =


### PR DESCRIPTION
This has occurred due to the availability of in equivalent parameters in the exchange which has already been created
in the rabbitmq console. Both Exchange and queue declaration is fixed with this.

Fixes wso2/micro-integrator#2376