### PR TITLE
Introduce new parameter to enable external auth mechanisms

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
@@ -21,6 +21,7 @@ package org.apache.axis2.transport.rabbitmq;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultSaslConfig;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -201,6 +202,8 @@ public class RabbitMQConnectionFactory extends BaseKeyedPooledObjectFactory<Stri
                 parameters.get(RabbitMQConstants.RETRY_COUNT), RabbitMQConstants.DEFAULT_RETRY_COUNT);
         boolean sslEnabled = BooleanUtils.toBooleanDefaultIfNull(
                 BooleanUtils.toBoolean(parameters.get(RabbitMQConstants.SSL_ENABLED)), false);
+        boolean externalAuthEnabled = BooleanUtils.toBooleanDefaultIfNull(
+                BooleanUtils.toBoolean(parameters.get(RabbitMQConstants.EXTERNAL_AUTH_MECHANISM)), false);
 
         String[] hostnameArray = hostnames.split(",");
         String[] portArray = ports.split(",");
@@ -226,6 +229,9 @@ public class RabbitMQConnectionFactory extends BaseKeyedPooledObjectFactory<Stri
         connectionFactory.setNetworkRecoveryInterval(networkRecoveryInterval);
         connectionFactory.setAutomaticRecoveryEnabled(true);
         connectionFactory.setTopologyRecoveryEnabled(true);
+        if (externalAuthEnabled) {
+            connectionFactory.setSaslConfig(DefaultSaslConfig.EXTERNAL);
+        }
         setSSL(parameters, sslEnabled, connectionFactory);
         return connectionFactory;
     }

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -60,6 +60,9 @@ public class RabbitMQConstants {
     public static final String QUEUE_AUTODECLARE = "rabbitmq.queue.autodeclare";
     public static final String EXCHANGE_AUTODECLARE = "rabbitmq.exchange.autodeclare";
 
+    // Authentication Mechanisms auth_mechanisms
+    public static final String EXTERNAL_AUTH_MECHANISM = "rabbitmq.auth.mechanism.external";
+
     //SSL related properties
     public static final String SSL_ENABLED = "rabbitmq.connection.ssl.enabled";
     public static final String SSL_KEYSTORE_LOCATION = "rabbitmq.connection.ssl.keystore.location";


### PR DESCRIPTION
## Purpose
This PR will introduce a new parameter to enable external auth mechanisms in RabbitMQ transport.
You can define the following property under `AMQPConnectionFactory` in axis2.xml file to enable [external auth mechanisms](https://www.rabbitmq.com/access-control.html#mechanisms). By default, the AMQPConnectionFactory will be using `SASL PLAIN authentication`.
```
<parameter name="rabbitmq.auth.mechanism.external" locked="false">true</parameter>
```

Fixes https://github.com/wso2/api-manager/issues/28