### PR TITLE
Provide support to OAuth2 authentication for mailTo transport Listener

### DIFF
--- a/modules/mail/pom.xml
+++ b/modules/mail/pom.xml
@@ -110,6 +110,16 @@
         </dependency>
         <dependency>
             <groupId>org.apache.axis2</groupId>
+            <artifactId>axis2-kernel</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-javamail_1.4_spec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-base</artifactId>
             <exclusions>
                 <!-- We want to choose the JavaMail implementation ourselves -->
@@ -142,6 +152,18 @@
                     <artifactId>mail</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailTransportListener.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/MailTransportListener.java
@@ -32,6 +32,8 @@ import org.apache.axis2.transport.base.ManagementSupport;
 import org.apache.axis2.transport.base.event.TransportErrorListener;
 import org.apache.axis2.transport.base.event.TransportErrorSource;
 import org.apache.axis2.transport.base.event.TransportErrorSourceSupport;
+import org.apache.axis2.transport.mail.auth.AuthConstants;
+import org.apache.axis2.transport.mail.auth.AuthUtils;
 
 import javax.mail.*;
 import javax.mail.internet.ContentType;
@@ -96,7 +98,6 @@ public class MailTransportListener extends AbstractPollingTransportListener<Poll
         int retryCount = 0;
         int maxRetryCount = entry.getMaxRetryCount();
         long reconnectionTimeout = entry.getReconnectTimeout();
-        Session session = entry.getSession();
         Store store = null;
         Folder folder = null;
         boolean nextPollScheduled = false;
@@ -105,22 +106,22 @@ public class MailTransportListener extends AbstractPollingTransportListener<Poll
             try {
                 retryCount++;
                 if (log.isDebugEnabled()) {
-                    log.debug("Attempting to connect to POP3/IMAP server for : " +
-                        entry.getEmailAddress() + " using " + session.getProperties());
+                    if (entry.getAuthMode().equalsIgnoreCase(AuthConstants.OAUTH)) {
+                        log.debug("Attempting to connect to " + entry.getProtocol() + " server for " +
+                                entry.getEmailAddress() + " with grant-type " + entry.getOAuthConfig().getGrantType());
+                    } else {
+                        log.debug("Attempting to connect to " + entry.getProtocol() + " server for : " +
+                                entry.getEmailAddress());
+                    }
                 }
 
-                store = session.getStore(entry.getProtocol());
-
-                if (entry.getUserName() != null && entry.getPassword() != null) {
-                    store.connect(entry.getUserName(), entry.getPassword());
-                } else {
-                    handleException("Unable to locate username and password for mail login", null);
-                }
+                store = AuthUtils.connect(entry);
 
                 // were we able to connect?
                 connected = store.isConnected();
 
                 if (connected) {
+                    log.debug("Successfully connected to mail server");
                     if (entry.getFolder() != null) {
                         folder = store.getFolder(entry.getFolder());
                     } else {
@@ -166,7 +167,7 @@ public class MailTransportListener extends AbstractPollingTransportListener<Poll
                 Message[] messages = folder.getMessages();
 
                 if (log.isDebugEnabled()) {
-                    log.debug(messages.length + " messgaes in folder : " + folder);
+                    log.debug(messages.length + " messages in folder : " + folder);
                 }
 
                 latch = new CountDownLatch(total);
@@ -175,7 +176,7 @@ public class MailTransportListener extends AbstractPollingTransportListener<Poll
                     try {
                         String[] status = messages[i].getHeader("Status");
                         if (status != null && status.length == 1 && status[0].equals("RO")) {
-                            // some times the mail server sends a special mail message which is
+                            // sometimes the mail server sends a special mail message which is
                             // not relavent in processing. ignore this message.
                             if (log.isDebugEnabled()) {
                                 log.debug("Skipping message # : " + messages[i].getMessageNumber()

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/PollTableEntry.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/PollTableEntry.java
@@ -24,11 +24,14 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
 
 import javax.mail.Session;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
+import org.apache.axiom.util.UIDGenerator;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.addressing.EndpointReference;
 import org.apache.axis2.description.AxisService;
@@ -37,6 +40,12 @@ import org.apache.axis2.description.ParameterInclude;
 import org.apache.axis2.transport.base.AbstractPollTableEntry;
 import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.ParamUtils;
+import org.apache.axis2.transport.mail.auth.AuthConstants;
+import org.apache.axis2.transport.mail.auth.oauth.OAuthConfig;
+import org.apache.axis2.transport.mail.auth.oauth.OAuthConstants;
+import org.apache.axis2.transport.mail.auth.oauth.Token;
+import org.apache.axis2.transport.mail.auth.oauth.TokenCache;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 
 /**
@@ -59,6 +68,8 @@ public class PollTableEntry extends AbstractPollTableEntry {
     private String password = null;
     /** The protocol to be used - pop3 or imap */
     private String protocol = null;
+    /** The authorization protocol to be used - oauth or basic */
+    private String authMode = "basic";
     /** The JavaMail session used to connect to the mail store */
     private Session session;
 
@@ -93,6 +104,7 @@ public class PollTableEntry extends AbstractPollTableEntry {
 
     private int maxRetryCount;
     private long reconnectTimeout;
+    private OAuthConfig oAuthConfig = new OAuthConfig();
 
     public PollTableEntry(Log log) {
         this.log = log;
@@ -166,6 +178,23 @@ public class PollTableEntry extends AbstractPollTableEntry {
         return protocol;
     }
 
+    /**
+     * Get the authorization mode.
+     *
+     * @return the authorization mode - OAUTH or BASIC
+     */
+    public String getAuthMode() {
+        return authMode;
+    }
+
+    public OAuthConfig getOAuthConfig() {
+        return oAuthConfig;
+    }
+
+    public void setOAuthConfig(OAuthConfig oAuthConfig) {
+        this.oAuthConfig = oAuthConfig;
+    }
+
     public Session getSession() {
         return session;
     }
@@ -224,9 +253,12 @@ public class PollTableEntry extends AbstractPollTableEntry {
 
             List<Parameter> params = paramIncl.getParameters();
             Properties props = new Properties();
+            Map<String, String> mailTransportOAuthProperties = new HashMap<String, String>();
             for (Parameter p : params) {
                 if (p.getName().startsWith("mail.")) {
                     props.setProperty(p.getName(), (String) p.getValue());
+                } else if (p.getName().startsWith("transport.mail.oauth")) {
+                    mailTransportOAuthProperties.put(p.getName(), (String) p.getValue());
                 }
 
                 if (MailConstants.MAIL_POP3_USERNAME.equals(p.getName()) ||
@@ -240,6 +272,13 @@ public class PollTableEntry extends AbstractPollTableEntry {
                 if (MailConstants.TRANSPORT_MAIL_PROTOCOL.equals(p.getName())) {
                     protocol = (String) p.getValue();
                 }
+                if (AuthConstants.TRANSPORT_MAIL_AUTH_MECHANISM.equals(p.getName())) {
+                    authMode = (String) p.getValue();
+                }
+            }
+
+            if(authMode.equalsIgnoreCase(AuthConstants.OAUTH)) {
+                updateOAuthConfig(mailTransportOAuthProperties);
             }
 
             session = Session.getInstance(props, null);
@@ -313,6 +352,33 @@ public class PollTableEntry extends AbstractPollTableEntry {
 
             return super.loadConfiguration(paramIncl);
         }
+    }
+
+    private void updateOAuthConfig(Map<String, String> mailTransportOAuthProperties) {
+        oAuthConfig.setGrantType(
+                mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_GRANT_TYPE));
+        oAuthConfig.setClientId(
+                mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_CLIENT_ID));
+        oAuthConfig.setClientSecret(
+                mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_CLIENT_SECRET));
+        oAuthConfig.setAccessToken(
+                mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_ACCESS_TOKEN));
+        oAuthConfig.setRefreshToken(
+                mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_REFRESH_TOKEN));
+        oAuthConfig.setScope(mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_SCOPE));
+        oAuthConfig.setTokenUrl(
+                mailTransportOAuthProperties.get(OAuthConstants.TRANSPORT_MAIL_OAUTH_TOKEN_URL));
+        oAuthConfig.setTokenId(UIDGenerator.generateUID());
+        setOAuthConfig(oAuthConfig);
+        if (StringUtils.isNotBlank(oAuthConfig.getAccessToken())) {
+            // this is a non-expiring token
+            updateTokenCache();
+        }
+    }
+
+    private void updateTokenCache() {
+        Token token = new Token(oAuthConfig.getAccessToken(), -1);
+        TokenCache.getInstance().addToken(oAuthConfig.getTokenId(), token);
     }
 
     public synchronized void processingUID(String uid) {

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthConstants.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.axis2.transport.mail.auth;
+
+/**
+ * Utility class defining constants used by the Auth handlers
+ */
+public class AuthConstants {
+
+    public static final String BASIC_AUTH = "basic";
+    public static final String OAUTH = "oauth";
+
+    public static final String TRANSPORT_MAIL_AUTH_MECHANISM = "transport.mail.auth.mechanism";
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthException.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.axis2.transport.mail.auth;
+
+/**
+ * Exceptions to be thrown when a Auth related errors occurs
+ */
+public class AuthException extends Exception {
+
+    public AuthException(String message, Throwable e) {
+
+        super(message, e);
+    }
+
+    public AuthException(String message) {
+
+        super(message);
+    }
+
+    public AuthException(Throwable e) {
+
+        super(e);
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthHandler.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthHandler.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.axis2.transport.mail.auth;
+
+import javax.mail.Session;
+import javax.mail.Store;
+
+public interface AuthHandler {
+
+    Store connect(Session session, String protocol) throws AuthException;
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthUtils.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/AuthUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.axis2.transport.mail.auth;
+
+import org.apache.axis2.transport.mail.PollTableEntry;
+import org.apache.axis2.transport.mail.auth.basic.BasicAuthHandler;
+import org.apache.axis2.transport.mail.auth.oauth.OAuthUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.mail.Session;
+import javax.mail.Store;
+
+/**
+ * Utility class to build OAuth and Basic handlers
+ */
+public class AuthUtils {
+
+    private static final Log log = LogFactory.getLog(AuthUtils.class);
+
+    /**
+     * This method will connect to mail server based on the auth configs provided.
+     * @param entry the PollTableEntry
+     * @return the mail store
+     * @throws AuthException throw exception upon failure
+     */
+    public static Store connect(PollTableEntry entry) throws AuthException {
+        AuthHandler authHandler = getAuthHandler(entry);
+        if (authHandler != null) {
+            Session session = entry.getSession();
+            return authHandler.connect(session, entry.getProtocol());
+        } else {
+            throw new AuthException("An invalid authHandler is returned.");
+        }
+    }
+
+    private static AuthHandler getAuthHandler(PollTableEntry entry) throws AuthException {
+        String authMode = entry.getAuthMode();
+        if (AuthConstants.OAUTH.equalsIgnoreCase(authMode)) {
+            return OAuthUtils.getOAuthHandler(entry.getUserName(), entry.getOAuthConfig());
+        } else if (AuthConstants.BASIC_AUTH.equalsIgnoreCase(authMode)) {
+            return getBasicAuthHandler(entry.getUserName(), entry.getPassword());
+        } else {
+            throw new AuthException("Provided auth mode : " + authMode + " is invalid.");
+        }
+    }
+
+    private static AuthHandler getBasicAuthHandler(String userName, String password) throws AuthException {
+
+        if (StringUtils.isBlank(userName) || StringUtils.isBlank(password)) {
+            log.error("Invalid basicAuth configurations provided.");
+            throw new AuthException("Invalid basicAuth configurations provided.");
+        }
+        return new BasicAuthHandler(userName, password);
+    }
+
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/basic/BasicAuthHandler.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/basic/BasicAuthHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.basic;
+
+import org.apache.axis2.transport.mail.auth.AuthException;
+import org.apache.axis2.transport.mail.auth.AuthHandler;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Store;
+
+/**
+ * This class is used to handle Basic Authorization.
+ */
+public class BasicAuthHandler implements AuthHandler {
+
+    private final String username;
+    private final String password;
+    private static final Log log = LogFactory.getLog(BasicAuthHandler.class);
+
+    public BasicAuthHandler(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public Store connect(Session session, String protocol) throws AuthException {
+        Store store = null;
+        log.debug("Connecting to email server via basic auth protocol");
+        try {
+            store = session.getStore(protocol);
+            store.connect(username, password);
+            return store;
+        } catch (MessagingException e) {
+            log.error("An error occurred while trying to connect to mail server for " + username + " via " +
+                    protocol + " protocol.");
+            throw new AuthException(e.getMessage(), e);
+        }
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/AuthorizationCodeHandler.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/AuthorizationCodeHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * This class is used to handle Authorization code grant oauth.
+ */
+public class AuthorizationCodeHandler extends OAuthHandler {
+
+    private static final Log log = LogFactory.getLog(AuthorizationCodeHandler.class);
+
+    private final String refreshToken;
+
+    public AuthorizationCodeHandler(String username, String clientId, String clientSecret, String refreshToken,
+                                    String tokenUrl, String tokenId) {
+        super(username, clientId, clientSecret, tokenUrl, tokenId);
+        this.refreshToken = refreshToken;
+    }
+
+    @Override
+    protected String buildTokenRequestPayload() {
+        return OAuthConstants.REFRESH_TOKEN_GRANT_TYPE +
+                OAuthConstants.PARAM_CLIENT_ID + getClientId() +
+                OAuthConstants.PARAM_CLIENT_SECRET + getClientSecret() +
+                OAuthConstants.PARAM_REFRESH_TOKEN + refreshToken;
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/ClientCredentialsHandler.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/ClientCredentialsHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * This class is used to handle Client Credentials grant oauth.
+ */
+public class ClientCredentialsHandler extends OAuthHandler {
+
+    private static final Log log = LogFactory.getLog(ClientCredentialsHandler.class);
+    private final String scope;
+
+    public ClientCredentialsHandler(String username, String clientId, String clientSecret, String scope,
+                                    String tokenUrl, String tokenId) {
+        super(username, clientId, clientSecret, tokenUrl, tokenId);
+        this.scope = scope;
+    }
+
+    @Override
+    protected String buildTokenRequestPayload() {
+        return OAuthConstants.CLIENT_CRED_GRANT_TYPE +
+                OAuthConstants.PARAM_CLIENT_ID + getClientId() +
+                OAuthConstants.PARAM_CLIENT_SECRET + getClientSecret() +
+                OAuthConstants.SCOPE + scope;
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthClient.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthClient.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+import org.apache.axis2.transport.mail.auth.AuthException;
+import org.apache.commons.httpclient.HttpStatus;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+/**
+ * This class represents the client used to request and retrieve OAuth tokens
+ * from an OAuth server
+ */
+public class OAuthClient {
+
+    private static final Log log = LogFactory.getLog(OAuthClient.class);
+
+    public static Token generateAccessToken(String url, Map<String, String> headers, String payload)
+            throws IOException, AuthException {
+        Token token;
+        if (log.isDebugEnabled()) {
+            log.debug("Initializing token generation request: [token-endpoint] " + url);
+        }
+        CloseableHttpClient httpClient = getHttpClient();
+        HttpPost httpPost = new HttpPost(url);
+        try {
+            for (Map.Entry<String, String> header : headers.entrySet()) {
+                httpPost.setHeader(header.getKey(), header.getValue());
+            }
+
+            httpPost.setEntity(new StringEntity(payload));
+            CloseableHttpResponse response = httpClient.execute(httpPost);
+            token = extractToken(response);
+        } finally {
+            httpClient.close();
+            httpPost.releaseConnection();
+        }
+        return token;
+    }
+
+    private static Token extractToken(CloseableHttpResponse response) throws AuthException, IOException {
+        int responseCode = response.getStatusLine().getStatusCode();
+
+        HttpEntity entity = response.getEntity();
+
+        Charset charset = ContentType.getOrDefault(entity).getCharset();
+        if (charset == null) {
+            charset = StandardCharsets.UTF_8;
+        }
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(entity.getContent(), charset));
+        String inputLine;
+        StringBuilder stringBuilder = new StringBuilder();
+
+        while ((inputLine = reader.readLine()) != null) {
+            stringBuilder.append(inputLine);
+        }
+
+        if (log.isDebugEnabled()) {
+            log.debug("Response: [status-code] " + responseCode);
+        }
+
+        if (responseCode != HttpStatus.SC_OK) {
+            throw new AuthException("Error occurred while accessing the Token URL. "
+                    + response.getStatusLine());
+        }
+
+        JsonParser parser = new JsonParser();
+        JsonObject jsonObject = (JsonObject) parser.parse(stringBuilder.toString());
+        if (jsonObject.has(OAuthConstants.ACCESS_TOKEN)) {
+            String accessToken = jsonObject.get(OAuthConstants.ACCESS_TOKEN).getAsString();
+            if (jsonObject.has(OAuthConstants.EXPIRES_IN)) {
+                long expiresIn = jsonObject.get(OAuthConstants.EXPIRES_IN).getAsLong();
+                long expiryTime = System.currentTimeMillis() + expiresIn * 1000;
+                return new Token(accessToken, expiryTime);
+            } else {
+                throw new AuthException("Missing key [" + OAuthConstants.EXPIRES_IN + "] " +
+                        "in the response from the OAuth server");
+            }
+        } else {
+            throw new AuthException("Missing key [" + OAuthConstants.ACCESS_TOKEN + "] " +
+                    "in the response from the OAuth server");
+        }
+    }
+
+    private static CloseableHttpClient getHttpClient() {
+        return HttpClientBuilder.create().build();
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthConfig.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+/**
+ * This class is used to add and get OAuth configurations
+ */
+public class OAuthConfig {
+    private String grantType = null;
+    private String clientId = null;
+    private String clientSecret = null;
+    private String accessToken = null;
+    private String refreshToken = null;
+    private String tokenUrl = null;
+    private String tokenId = null;
+    private String scope = null;
+
+    public String getGrantType() {
+        return grantType;
+    }
+
+    public void setGrantType(String grantType) {
+        this.grantType = grantType;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public String getTokenUrl() {
+        return tokenUrl;
+    }
+
+    public void setTokenUrl(String tokenUrl) {
+        this.tokenUrl = tokenUrl;
+    }
+
+    public String getTokenId() {
+        return tokenId;
+    }
+
+    public void setTokenId(String tokenId) {
+        this.tokenId = tokenId;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthConstants.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthConstants.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+/**
+ * Utility class defining constants used by the OAuth handlers
+ */
+public class OAuthConstants {
+    public static final String TRANSPORT_MAIL_OAUTH_GRANT_TYPE = "transport.mail.oauth.grantType";
+    public static final String TRANSPORT_MAIL_OAUTH_CLIENT_ID = "transport.mail.oauth.clientId";
+    public static final String TRANSPORT_MAIL_OAUTH_CLIENT_SECRET = "transport.mail.oauth.clientSecret";
+    public static final String TRANSPORT_MAIL_OAUTH_ACCESS_TOKEN = "transport.mail.oauth.accessToken";
+    public static final String TRANSPORT_MAIL_OAUTH_REFRESH_TOKEN = "transport.mail.oauth.refreshToken";
+    public static final String TRANSPORT_MAIL_OAUTH_SCOPE = "transport.mail.oauth.scope";
+    public static final String TRANSPORT_MAIL_OAUTH_TOKEN_URL = "transport.mail.oauth.tokenUrl";
+    public static final String AUTHORIZATION_CODE_GRANT_TYPE = "authorization_code";
+    public static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+
+    public static final String HEADER_CONTENT_TYPE = "Content-Type";
+    public static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
+
+    public static final String CLIENT_CRED_GRANT_TYPE = "grant_type=client_credentials";
+    public static final String REFRESH_TOKEN_GRANT_TYPE = "grant_type=refresh_token";
+
+    // parameters used to build oauth requests
+    public static final String PARAM_USERNAME = "&username=";
+    public static final String PARAM_PASSWORD = "&password=";
+    public static final String PARAM_CLIENT_ID = "&client_id=";
+    public static final String PARAM_CLIENT_SECRET = "&client_secret=";
+    public static final String PARAM_REFRESH_TOKEN = "&refresh_token=";
+    public static final String SCOPE = "&scope=";
+    public static final String AMPERSAND = "&";
+    public static final String EQUAL_MARK = "=";
+
+    // elements in the oauth response
+    public static final String ACCESS_TOKEN = "access_token";
+    public static final String EXPIRES_IN = "expires_in";
+
+    public static final String AUTHENTICATE_FAIL_EXCEPTION_MESSAGE = "authenticate failed";
+
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthHandler.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthHandler.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+import org.apache.axis2.transport.mail.auth.AuthException;
+import org.apache.axis2.transport.mail.auth.AuthHandler;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.mail.Session;
+import javax.mail.Store;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This abstract class is to be used by OAuth handlers
+ * This class checks validity of tokens, request for tokens and add tokens to in-memory cache
+ */
+public abstract class OAuthHandler implements AuthHandler {
+    private static final Log log = LogFactory.getLog(OAuthHandler.class);
+
+    private final String username;
+    private final String clientId;
+    private final String clientSecret;
+    private final String tokenUrl;
+    private final String tokenId;
+
+    protected OAuthHandler(String username, String clientId, String clientSecret, String tokenUrl, String tokenId) {
+        this.username = username;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.tokenUrl = tokenUrl;
+        this.tokenId = tokenId;
+    }
+
+    public Store connect(Session session, String protocol) throws AuthException {
+        try {
+            Store store = session.getStore(protocol);
+            try {
+                if (log.isDebugEnabled()) {
+                    log.debug("Connecting to mail service for " + username + " via " + protocol + " protocol.");
+                }
+                store.connect(username, getToken());
+                return store;
+            } catch (Exception e) {
+                log.error("An error occurred while trying to connect to mail server for " + username + " via " +
+                        protocol + " protocol.");
+                if (e.getMessage().toLowerCase().contains(OAuthConstants.AUTHENTICATE_FAIL_EXCEPTION_MESSAGE)) {
+                    removeTokenFromCache();
+                    return retryToConnect(store);
+                } else {
+                    throw e;
+                }
+            }
+        } catch (Exception e) {
+            throw new AuthException(e.getMessage(), e);
+        }
+    }
+
+    private Store retryToConnect(Store store) throws AuthException {
+        log.info("Retrying to connect to mail service upon authentication failure");
+        try {
+            store.connect(username, getToken());
+        } catch (Exception e) {
+            log.error("An error occurred while retrying to connect to mail server.");
+            throw new AuthException("An error occurred while retrying to connect to mail server", e);
+        }
+        return store;
+    }
+
+    private void removeTokenFromCache() {
+        TokenCache.getInstance().removeToken(tokenId);
+    }
+
+    private String getToken() throws AuthException {
+        TokenCache tokenCache = TokenCache.getInstance();
+        Token token = tokenCache.getTokenObject(tokenId);
+        if (null == token || StringUtils.isEmpty(token.getAccessToken()) ||
+                isAccessTokenExpired(token.getExpiryTime())) {
+            token = refreshAccessToken();
+            tokenCache.addToken(tokenId, token);
+        }
+        return token.getAccessToken();
+    }
+
+    private boolean isAccessTokenExpired(long expiryTime) {
+        if (expiryTime != -1) {
+            return (System.currentTimeMillis() >= expiryTime);
+        }
+        return false;
+    }
+
+    private Token refreshAccessToken() throws AuthException {
+        log.info("Refreshing access token in mail transport");
+        Map<String,String> headers = new HashMap<>();
+        headers.put(OAuthConstants.HEADER_CONTENT_TYPE, OAuthConstants.APPLICATION_X_WWW_FORM_URLENCODED);
+        try {
+            return OAuthClient.generateAccessToken(getTokenUrl(), headers, buildTokenRequestPayload());
+        } catch (IOException e) {
+            throw new AuthException(e.getCause());
+        }
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public String getTokenUrl() {
+        return tokenUrl;
+    }
+
+    public String getTokenId() {
+        return tokenId;
+    }
+
+    protected abstract String buildTokenRequestPayload();
+
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthUtils.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/OAuthUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+import org.apache.axis2.transport.mail.auth.AuthException;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * Utility class to build OAuth handlers
+ * Currently this supports only authorization_code and client_credentials grant type
+ */
+public class OAuthUtils {
+
+    static final Log log = LogFactory.getLog(OAuthUtils.class);
+    public static OAuthHandler getOAuthHandler(String userName, OAuthConfig oAuthConfig) throws AuthException {
+        String grantType = oAuthConfig.getGrantType();
+        switch (grantType) {
+            case OAuthConstants.AUTHORIZATION_CODE_GRANT_TYPE :
+                return getAuthorizationCodeHandler(userName, oAuthConfig);
+            case OAuthConstants.CLIENT_CREDENTIALS_GRANT_TYPE:
+                return getClientCredentialsHandler(userName, oAuthConfig);
+            default:
+                throw new AuthException("Grant type " + grantType + " is invalid");
+        }
+    }
+
+    private static OAuthHandler getAuthorizationCodeHandler(String userName, OAuthConfig oAuthConfig)
+            throws AuthException {
+        String clientId = oAuthConfig.getClientId();
+        String clientSecret = oAuthConfig.getClientSecret();
+        String refreshToken = oAuthConfig.getRefreshToken();
+        String tokenUrl = oAuthConfig.getTokenUrl();
+        if (StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret) ||
+                StringUtils.isBlank(refreshToken) || StringUtils.isBlank(tokenUrl)) {
+            throw new AuthException("Invalid configurations provided for authorization code grant type.");
+        }
+        return new AuthorizationCodeHandler(userName, clientId, clientSecret, refreshToken, tokenUrl,
+                oAuthConfig.getTokenId());
+    }
+
+    private static OAuthHandler getClientCredentialsHandler(String userName, OAuthConfig oAuthConfig) throws AuthException {
+        String clientId = oAuthConfig.getClientId();
+        String clientSecret = oAuthConfig.getClientSecret();
+        String tokenUrl = oAuthConfig.getTokenUrl();
+        String scope = oAuthConfig.getScope();
+        if (StringUtils.isBlank(clientId) || StringUtils.isBlank(clientSecret) || StringUtils.isBlank(scope) ||
+                StringUtils.isBlank(tokenUrl)) {
+            throw new AuthException("Invalid configurations provided for client credentials grant type.");
+        }
+        return new ClientCredentialsHandler(userName, clientId, clientSecret, scope, tokenUrl,
+                oAuthConfig.getTokenId());
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/Token.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/Token.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+/**
+ * Token object to add and update accessToken and expiry time
+ */
+public class Token {
+    private String accessToken;
+    private long expiryTime;
+
+    public Token(String accessToken, long expiryTime) {
+        this.accessToken = accessToken;
+        this.expiryTime = expiryTime;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public long getExpiryTime() {
+        return expiryTime;
+    }
+
+    public void setExpiryTime(long expiryTime) {
+        this.expiryTime = expiryTime;
+    }
+}

--- a/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/TokenCache.java
+++ b/modules/mail/src/main/java/org/apache/axis2/transport/mail/auth/oauth/TokenCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC (http://www.wso2.com).
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.axis2.transport.mail.auth.oauth;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.HashMap;
+
+/**
+ * Singleton class to maintain in-memory token cache
+ */
+public class TokenCache {
+    private static final Log log = LogFactory.getLog(TokenCache.class);
+
+    private static TokenCache tokenCache;
+    private HashMap<String, Token> tokenMap;
+
+    private TokenCache() {
+
+    }
+
+    public static TokenCache getInstance() {
+        if (tokenCache == null) {
+            tokenCache = new TokenCache();
+        }
+        return tokenCache;
+    }
+
+    public Token getTokenObject(String id) {
+        return getTokenMap().get(id);
+    }
+
+    public void addToken(String key, Token token) {
+        getTokenMap().put(key, token);
+    }
+
+    public void removeToken(String id) {
+        getTokenMap().remove(id);
+    }
+
+    private HashMap<String, Token> getTokenMap() {
+        if (null == tokenMap) {
+            tokenMap = new HashMap<>();
+        }
+        return tokenMap;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,16 @@
                 <version>4.2.3</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient.wso2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${com.google.code.gson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-logging</groupId>
                 <artifactId>commons-logging</artifactId>
                 <version>1.1.1</version>
@@ -682,5 +692,7 @@
         <powermock.version>2.0.9</powermock.version>
         <junit.version>4.12</junit.version>
         <version.org.wso2.orbit.javax.activation>1.1.1.wso2v2</version.org.wso2.orbit.javax.activation>
+        <httpclient.wso2.version>4.5.13.wso2v1</httpclient.wso2.version>
+        <com.google.code.gson.version>2.9.0</com.google.code.gson.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/api-manager/issues/1029

**Introduced parameters are as follows.**
Parameter | Description | Possible Values | Default Value | Required
-- | -- | -- | -- | --
transport.mail.auth.mechanism | basic authentication or oauth authentication | basic, oauth | basic | Default is set to basic.
transport.mail.oauth.grantType | grant type | authorization_code, client_credentials | - | Required if the auth mechanism is oauth
transport.mail.oauth.clientId | client id | - | - | Required if the auth mechanism is oauth
transport.mail.oauth.clientSecret | client secret | - | - | Required if the auth mechanism is oauth
transport.mail.oauth.tokenUrl | token endpoint url | - | - | Required if the auth mechanism is oauth
transport.mail.oauth.scope | scope | - | - | Required if the grant type is client_credentials
transport.mail.oauth.refreshToken | refresh token generated | - | - | Required if the grant type is authorization_code
transport.mail.oauth.accessToken | access token generated | - | - | Optional

