### PR TITLE
Fix returning null connection on TimeoutException

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
@@ -80,7 +80,9 @@ public class RabbitMQUtils {
         try {
             connection = factory.newConnection(addresses);
         } catch (TimeoutException e) {
-            log.error("Error occurred while creating a connection", e);
+            //Since we are throwing a IOException, the createConnection method in RMQConnectionFactory will log error
+            //Hence omitting logging the error here
+            throw new IOException("Timeout occurred when creating the new connection", e);
         }
         return connection;
     }


### PR DESCRIPTION
    

## Purpose
     Previously the issue here is previously we have caught a
    TimeOutException when creating the actual RabbitMq connection
    from the RabbitMqUtils class in axis2transports and logging it as a warn log.
    So we are returning a null connection without retrying.
    Fixed this by throwing IOException rather than just logging

    Fixes: https://github.com/wso2/api-manager/issues/2127