### PR TITLE
Fixed setting poolSize value for RabbitMQ ConnectionFactory in Axis2 RabbitMQ transport

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionPool.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionPool.java
@@ -36,6 +36,7 @@ public class RabbitMQConnectionPool extends GenericKeyedObjectPool<String, Conne
         super(factory);
         this.setTestOnBorrow(true);
         this.setMaxTotal(poolSize);
+        this.setMaxTotalPerKey(poolSize);
     }
 
     /**

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -109,7 +109,7 @@ public class RabbitMQConstants {
 
     public static final String SECURE_VAULT_NAMESPACE = "http://org.wso2.securevault/configuration";
     public static final String SECRET_ALIAS_ATTRIBUTE = "secretAlias";
-    public static final String PARAM_POOL_SIZE = "poolSize";
+    public static final String PARAM_POOL_SIZE = "rabbitmq.connection.pool.size";
 
     public static final String EXCHANGE_TYPE_DEFAULT = BuiltinExchangeType.DIRECT.getType();
     public static final String EXCHANGE_DURABLE_DEFAULT = "true";

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQUtils.java
@@ -351,6 +351,13 @@ public class RabbitMQUtils {
                 for (Parameter p : pi.getParameters()) {
                     OMElement paramElement = p.getParameterElement();
                     String propertyValue = p.getValue().toString();
+                    if (StringUtils.equals(p.getName(), RabbitMQConstants.PARAM_POOL_SIZE)) {
+                        try {
+                            poolSize = Integer.parseInt(propertyValue);
+                        } catch (NumberFormatException e) {
+                            throw new AxisRabbitMQException("Pool size must be an integer value.");
+                        }
+                    }
                     if (paramElement != null) {
                         OMAttribute attribute = paramElement.getAttribute(
                                 new QName(RabbitMQConstants.SECURE_VAULT_NAMESPACE,


### PR DESCRIPTION

## Purpose
Fixed following issues in Axis2 RabbitMQ transport

>  1. Set poolSize for RabbitMQ ConnectionFactory 
> 2. Fixed issue in not reflecting toml conf values

Fixes: https://github.com/wso2/wso2-axis2-transports/issues/335