### PR TITLE
Fix thread hanging issue when deploying multiple RabbitMq listener proxies

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQEndpoint.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQEndpoint.java
@@ -109,11 +109,10 @@ public class RabbitMQEndpoint extends ProtocolEndpoint {
     private ServiceTaskManager createServiceTaskManager(String factoryName, AxisService service, WorkerPool workerPool) {
 
         RabbitMQConnectionFactory rabbitMQConnectionFactory = rabbitMQListener.getRabbitMQConnectionFactory();
-        RabbitMQConnectionPool rabbitMQConnectionPool = rabbitMQListener.getRabbitMQConnectionPool();
         String serviceName = service.getName();
         Map<String, String> serviceParameters = getServiceStringParameters(service.getParameters());
         Map<String, String> cfParameters = rabbitMQConnectionFactory.getConnectionFactoryConfiguration(factoryName);
-        ServiceTaskManager taskManager = new ServiceTaskManager(rabbitMQConnectionPool, factoryName);
+        ServiceTaskManager taskManager = new ServiceTaskManager(rabbitMQConnectionFactory, factoryName);
 
         taskManager.setServiceName(serviceName);
         taskManager.addRabbitMQProperties(cfParameters);


### PR DESCRIPTION



## Purpose
After reviewing the Axis2 Transport code, it became evident that maintaining a shared connection pool is unnecessary. This is because for every deployed Listener Proxy, a new ServiceTaskManager is instantiated through RabbitMQEndpoint. So for each Proxy, a unique instance of ServiceTaskManager is available and the Connection is held by ServiceTaskManager.
So parallelization of connections through a pool is not needed at this level since parallelization happens at MessageListenerTask (inner class of ServiceTaskManager)

Here also we no longer need to implement caching or pooling since each MessageListenerTask has its own channel created on the connection of ServiceTaskManager and  RabbitMQ supports creating multiple channels over a single connection. This is one of the design choices of the RabbitMQ protocol, AMQP. Therefore, by this, I changed the design to hand over connection management to reside within the ServiceTaskManager rather than for each STM having the same shared connection pool.

Fixes: https://github.com/wso2/wso2-axis2-transports/issues/335
