### PR TITLE
Add exponential time retry mechanism for JMS IllegalStateException

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -715,8 +715,18 @@ public class ServiceTaskManager {
                     consumerRetryCount = 0;
                     return msg;
                 }
-            } catch (IllegalStateException ignore) {
+            } catch (IllegalStateException e) {
                 // probably the consumer (shared) was closed.. which is still ok.. as we didn't read
+                connectionReceivedError = true;
+                consumerRetryCount++;
+                if (consumerRetryCount <= maxConsumeErrorRetryBeforeDelay) {
+                    log.warn("Could not consume message from: " +
+                            serviceName + ". Expect " + (maxConsumeErrorRetryBeforeDelay - consumerRetryCount) + " more " +
+                            "retries before exponential sleep!");
+                }
+                if (log.isDebugEnabled()) {
+                    log.debug("Error receiving message for service : " + serviceName, e);
+                }
             } catch (JMSException e) {
                 connectionReceivedError  = true;
                 consumerRetryCount++;


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This will prevent the thread from going into a continuous loop when IllegalStateException is thrown continuously due to connection issues. 

Resolves https://github.com/wso2/micro-integrator/issues/3008