### PR TITLE
Fix connection leakage in RabbitMq Sender

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQChannelPool.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQChannelPool.java
@@ -23,7 +23,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 /**
  * Pool implementation for the rabbitmq channel associating with the connection factory name
@@ -32,17 +34,74 @@ public class RabbitMQChannelPool extends GenericKeyedObjectPool<String, Channel>
 
     private static final Log log = LogFactory.getLog(RabbitMQChannelPool.class);
 
-    public RabbitMQChannelPool(RabbitMQChannelFactory rabbitMQChannelFactory, int poolSize) {
+    public RabbitMQChannelPool(RabbitMQChannelFactory rabbitMQChannelFactory, int poolSize, RabbitMQConnectionFactory
+            factory) {
         super(rabbitMQChannelFactory);
         this.setTestOnBorrow(true);
         this.setMaxTotal(poolSize);
+        Map<String, String> evictionParams = factory.getConnectionFactoryConfiguration
+                (RabbitMQConstants.EVICTION_STRATEGY_PARAMETERS);
+        if (evictionParams != null) {
+            // For int values
+            trySetIntParam(evictionParams, RabbitMQConstants.MAX_IDLE_PER_KEY, this::setMaxIdlePerKey);
+            trySetIntParam(evictionParams, RabbitMQConstants.MAX_IDLE_PER_KEY, this::setMaxTotalPerKey);
+
+            // For long values
+            trySetLongParam(evictionParams, RabbitMQConstants.MAX_WAIT_MILLIS, this::setMaxWaitMillis);
+            trySetLongParam(evictionParams, RabbitMQConstants.MIN_EVICTABLE_IDLE_TIME,
+                    this::setMinEvictableIdleTimeMillis);
+            trySetLongParam(evictionParams, RabbitMQConstants.TIME_BETWEEN_EVICTION_RUNS
+                    , this::setTimeBetweenEvictionRunsMillis);
+            this.setTestWhileIdle(true); // Optionally, test objects for validity while idle
+        }
     }
 
-    public RabbitMQChannelPool(RabbitMQConfirmChannelFactory rabbitMQConfirmChannelFactory, int poolSize) {
+    public RabbitMQChannelPool(RabbitMQConfirmChannelFactory rabbitMQConfirmChannelFactory, int poolSize,
+                               RabbitMQConnectionFactory factory) {
         super(rabbitMQConfirmChannelFactory);
         this.setTestOnBorrow(true);
         this.setMaxTotal(poolSize);
+        Map<String, String> evictionParams = factory.getConnectionFactoryConfiguration
+                (RabbitMQConstants.EVICTION_STRATEGY_PARAMETERS);
+        if (evictionParams != null) {
+            // For int values
+            trySetIntParam(evictionParams, RabbitMQConstants.MAX_IDLE_PER_KEY, this::setMaxIdlePerKey);
+            trySetIntParam(evictionParams, RabbitMQConstants.MAX_IDLE_PER_KEY, this::setMaxTotalPerKey);
+
+            // For long values
+            trySetLongParam(evictionParams, RabbitMQConstants.MAX_WAIT_MILLIS, this::setMaxWaitMillis);
+            trySetLongParam(evictionParams, RabbitMQConstants.MIN_EVICTABLE_IDLE_TIME,
+                    this::setMinEvictableIdleTimeMillis);
+            trySetLongParam(evictionParams, RabbitMQConstants.TIME_BETWEEN_EVICTION_RUNS
+                    , this::setTimeBetweenEvictionRunsMillis);
+            this.setTestWhileIdle(true); // Optionally, test objects for validity while idle
+        }
     }
+
+    // Helper method for int parameters
+    private void trySetIntParam(Map<String, String> params, String key, Consumer<Integer> setter) {
+        String value = params.get(key);
+        if (value != null) {
+            try {
+                setter.accept(Integer.parseInt(value));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid value for " + key + " : " + value);
+            }
+        }
+    }
+
+    // Helper method for long parameters
+    private void trySetLongParam(Map<String, String> params, String key, Consumer<Long> setter) {
+        String value = params.get(key);
+        if (value != null) {
+            try {
+                setter.accept(Long.parseLong(value));
+            } catch (NumberFormatException e) {
+                log.warn("Invalid value for " + key + " : " + value);
+            }
+        }
+    }
+
 
     /**
      * Obtains an instance from the pool for the specified key

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
@@ -164,6 +164,16 @@ public class RabbitMQConnectionFactory extends BaseKeyedPooledObjectFactory<Stri
     }
 
     /**
+     * Remove configuration parameters by the factory name
+     *
+     * @param factoryName factory name to get the parameters
+     * @return map of parameters of the connection factory
+     */
+    public Map<String, String> removeConnectionFactoryConfiguration(String factoryName) {
+        return connectionFactoryConfigurations.remove(factoryName);
+    }
+
+    /**
      * Add connection factory parameters by the connection factory name
      *
      * @param name       connection factory name

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -115,6 +115,14 @@ public class RabbitMQConstants {
     public static final String SECRET_ALIAS_ATTRIBUTE = "secretAlias";
     public static final String PARAM_POOL_SIZE = "poolSize";
 
+    public static final String EVICTION_STRATEGY_PARAMETERS = "EVICTION_STRATEGY_PARAMETERS";
+
+    public static final String MIN_EVICTABLE_IDLE_TIME = "rabbitmq.min.evictable.idle.time";
+    public static final String TIME_BETWEEN_EVICTION_RUNS = "rabbitmq.time.between.eviction.runs";
+    public static final String MAX_IDLE_PER_KEY = "rabbitmq.max.idle.per.key";
+    public static final String MAX_WAIT_MILLIS = "rabbitmq.max.wait.millis";
+    public static final String CONNECTION_POOL_SIZE = "rabbitmq.connection.pool.size";
+
     public static final String EXCHANGE_TYPE_DEFAULT = BuiltinExchangeType.DIRECT.getType();
     public static final String EXCHANGE_DURABLE_DEFAULT = "true";
     public static final String QUEUE_DURABLE_DEFAULT = "true";


### PR DESCRIPTION


## Purpose
Fixed issue with connection leakage in high loadconditions when the rab bitMq server restarts.Previously, RabbitMQ connections were not being returned to the pool nor invalidated, resulting in all connections
being in a used state while their references were set to null. This update includes a redesign of the connection handling process to ensure proper management and return of connections. Additionally, implemented a robust idle connection eviction mechanism to prevent similar issues in the future.

Fixes: https://github.com/wso2/micro-integrator/issues/3076

Then Fine tune eviction strategy of connection pool Introduce parameters to fine tune connection pool's eviction strategy.

Fixes: https://github.com/wso2/micro-integrator/issues/3076