### PR TITLE
Prevent connection termination on unexpected build errors

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageReceiver.java
@@ -63,8 +63,8 @@ public class RabbitMQMessageReceiver {
             listener.handleIncomingMessage(msgContext, RabbitMQUtils.getTransportHeaders(messageProperties),
                                            RabbitMQUtils.getSoapAction(messageProperties), contentType);
             return getAcknowledgementMode(msgContext);
-        } catch (AxisFault axisFault) {
-            log.error("Error when trying to read incoming message.", axisFault);
+        } catch (Throwable fault) {
+            log.error("Error when trying to read incoming message.", fault);
             return AcknowledgementMode.REQUEUE_FALSE;
         }
     }


### PR DESCRIPTION

## Purpose

Updated the catch block to handle all `Throwable` instances instead of only `AxisFault`. This prevents connection termination when unexpected build-time errors occur, ensuring better stability during message processing.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4233
