### PR TITLE
 Fix issues in RabbitMQ publisher side

### DIFF
--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory.java
@@ -204,6 +204,8 @@ public class RabbitMQConnectionFactory extends BaseKeyedPooledObjectFactory<Stri
                 parameters.get(RabbitMQConstants.HEARTBEAT), ConnectionFactory.DEFAULT_HEARTBEAT);
         int connectionTimeout = NumberUtils.toInt(
                 parameters.get(RabbitMQConstants.CONNECTION_TIMEOUT), ConnectionFactory.DEFAULT_CONNECTION_TIMEOUT);
+        int handshakeTimeout = NumberUtils.toInt(
+                parameters.get(RabbitMQConstants.HANDSHAKE_TIMEOUT), ConnectionFactory.DEFAULT_HANDSHAKE_TIMEOUT);
         long networkRecoveryInterval = NumberUtils.toLong(
                 parameters.get(RabbitMQConstants.NETWORK_RECOVERY_INTERVAL), ConnectionFactory.DEFAULT_NETWORK_RECOVERY_INTERVAL);
         this.retryInterval = NumberUtils.toInt(
@@ -237,6 +239,7 @@ public class RabbitMQConnectionFactory extends BaseKeyedPooledObjectFactory<Stri
         connectionFactory.setVirtualHost(virtualHost);
         connectionFactory.setRequestedHeartbeat(heartbeat);
         connectionFactory.setConnectionTimeout(connectionTimeout);
+        connectionFactory.setHandshakeTimeout(handshakeTimeout);
         connectionFactory.setNetworkRecoveryInterval(networkRecoveryInterval);
         connectionFactory.setAutomaticRecoveryEnabled(true);
         connectionFactory.setTopologyRecoveryEnabled(true);

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -42,6 +42,7 @@ public class RabbitMQConstants {
 
     public static final String HEARTBEAT = "rabbitmq.connection.factory.heartbeat";
     public static final String CONNECTION_TIMEOUT = "rabbitmq.connection.factory.timeout";
+    public static final String HANDSHAKE_TIMEOUT = "rabbitmq.connection.factory.handshake.timeout";
     public static final String NETWORK_RECOVERY_INTERVAL = "rabbitmq.connection.factory.network.recovery.interval";
     public static final String RETRY_INTERVAL = "rabbitmq.connection.retry.interval";
     public static final String RETRY_COUNT = "rabbitmq.connection.retry.count";

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -50,6 +50,7 @@ public class RabbitMQConstants {
 
     public static final String CORRELATION_ID = "rabbitmq.message.correlation.id";
     public static final String MESSAGE_ID = "rabbitmq.message.id";
+    public static final String REPLY_TO_QUEUE_NAME = "rabbitmq.replyto.name";
     public static final String CONTENT_TYPE = "rabbitmq.message.content.type";
     public static final String CONTENT_ENCODING = "rabbitmq.message.content.encoding";
     public static final String EXPIRATION = "rabbitmq.message.expiration";

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -28,7 +28,9 @@ public class RabbitMQConstants {
     public static final String CONTENT_TYPE_PROPERTY_PARAM = "rabbitmq.transport.ContentTypeProperty";
     public static final String RABBITMQ_REPLY_TO = "RABBITMQ_REPLY_TO";
     public static final String RABBITMQ_WAIT_REPLY = "RABBITMQ_WAIT_REPLY";
+    public static final String RABBITMQ_WAIT_REPLY_TIMEOUT = "rabbitmq.wait.reply.timeout";
     public static final String RABBITMQ_WAIT_CONFIRMS = "RABBITMQ_WAIT_CONFIRMS";
+    public static final String RABBITMQ_PUBLISHER_CONFIRMS_WAIT_TIMEOUT = "rabbitmq.publisher.confirms.wait.timeout";
     public static final String SOAP_ACTION = "SOAP_ACTION";
     public static final String SET_REQUEUE_ON_ROLLBACK = "SET_REQUEUE_ON_ROLLBACK";
 

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQMessageSender.java
@@ -116,6 +116,11 @@ public class RabbitMQMessageSender {
                 RabbitMQConstants.DEFAULT_DELIVERY_MODE);
         builder.deliveryMode(deliveryMode);
 
+            String replyTo = rabbitMQProperties.get(RabbitMQConstants.REPLY_TO_QUEUE_NAME);
+            if (StringUtils.isEmpty(replyTo)) {
+                builder.replyTo(replyTo);
+            }
+
             long replyTimeout = NumberUtils.toLong((String) msgContext.getProperty(RabbitMQConstants.RABBITMQ_WAIT_REPLY),
                     RabbitMQConstants.DEFAULT_RABBITMQ_TIMEOUT);
 
@@ -140,7 +145,7 @@ public class RabbitMQMessageSender {
             return response;
 
         } catch (Exception e) {
-            if (channelChanged) {
+            if (channelChanged && channel != null) {
                 invalidateChannel(senderType, factoryName, channel);
                 channel = null;
             }
@@ -175,7 +180,7 @@ public class RabbitMQMessageSender {
             // if already assigned a new channel then we need to invalidate that as well.
             //So new one will be either returned or destroyed ath the finally block of the send method
             //The oldest reference will be destroyed or returned to the pool by RabbitMq Sender
-            if (channelChanged) {
+            if (channelChanged && channel != null) {
                 invalidateChannel(senderType, factoryName, channel);
                 channel = null;
             }


### PR DESCRIPTION
This PR makes the following changes:

1. Introduce a parameter `rabbitmq.connection.factory.handshake.timeout` to configure the RabbitMQ connection handshake timeout.
2. Make `rabbitmq.replyto.name` parameter effective on the publisher side.
3. Prevent the null channel from being invalidated.
4. Introduce new RabbitMQ parameters to configure publisher confirm wait timeout - `rabbitmq.publisher.confirms.wait.timeout` and waiting timeout for RPC publishing - `rabbitmq.wait.reply.timeout`.

Fixes https://github.com/wso2/product-micro-integrator/issues/4294
