### PR TITLE
Implement graceful shutdown for JMS and Rabbitmq listeners

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSListener.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/JMSListener.java
@@ -293,6 +293,7 @@ public class JMSListener extends AbstractTransportListenerEx<JMSEndpoint> implem
      */
     @Override
     protected void stopEndpoint(JMSEndpoint endpoint) {
+        boolean listenerShuttingDown = (state == BaseConstants.STOPPED);
         if (endpoint.isJMSSpec31()) {
             org.apache.axis2.transport.jms.jakarta.ServiceTaskManager stm = endpoint.getJakartaServiceTaskManager();
             if (log.isDebugEnabled()) {
@@ -300,7 +301,7 @@ public class JMSListener extends AbstractTransportListenerEx<JMSEndpoint> implem
                         " for service : " + stm.getServiceName());
             }
 
-            stm.stop();
+            stm.stop(listenerShuttingDown);
 
             log.info("Stopped listening for JMS messages to service : " + endpoint.getServiceName());
         } else {
@@ -310,7 +311,7 @@ public class JMSListener extends AbstractTransportListenerEx<JMSEndpoint> implem
                         " for service : " + stm.getServiceName());
             }
 
-            stm.stop();
+            stm.stop(listenerShuttingDown);
 
             log.info("Stopped listening for JMS messages to service : " + endpoint.getServiceName());
         }

--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/jakarta/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/jakarta/ServiceTaskManager.java
@@ -22,6 +22,7 @@ import org.apache.axis2.transport.base.BaseConstants;
 import org.apache.axis2.transport.base.threads.WorkerPool;
 import org.apache.axis2.transport.jms.AxisJMSException;
 import org.apache.axis2.transport.jms.JMSConstants;
+import org.apache.axis2.util.GracefulShutdownTimer;
 import org.apache.commons.lang.time.DateUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -261,15 +262,20 @@ public class ServiceTaskManager {
     }
 
     /**
-     * Shutdown the tasks and release any shared resources
+     * Shutdown the tasks and release any shared resources.
      */
     public synchronized void stop() {
+        this.stop(false);
+    }
+
+    /**
+     * Shutdown the tasks and release any shared resources.
+     */
+    public synchronized void stop(boolean listenerShuttingDown) {
 
         serviceTaskManagerState = STATE_SHUTTING_DOWN;
 
-        if (log.isDebugEnabled()) {
-            log.debug("Stopping ServiceTaskManager for service : " + serviceName);
-        }
+        log.info("Stopping the Jakarta Task Manager for service: " + serviceName);
 
         synchronized(pollingTasks) {
             for (MessageListenerTask lstTask : pollingTasks) {
@@ -277,14 +283,21 @@ public class ServiceTaskManager {
             }
         }
 
-        // try to wait a bit for task shutdown
-        for (int i=0; i<5; i++) {
-            if (activeTaskCount.get() == 0) {
-                break;
+        GracefulShutdownTimer gracefulShutdownTimer = GracefulShutdownTimer.getInstance();
+        if (listenerShuttingDown && gracefulShutdownTimer.isStarted()) {
+            log.info("Awaiting completion of active Jakarta tasks for service '" + serviceName
+                    + "' during graceful shutdown.");
+            waitForGracefulTaskCompletion(gracefulShutdownTimer);
+        } else {
+            // try to wait a bit for task shutdown
+            for (int i = 0; i < 5; i++) {
+                if (activeTaskCount.get() == 0) {
+                    break;
+                }
+                try {
+                    Thread.sleep(getReceiveTimeout());
+                } catch (InterruptedException ignore) {}
             }
-            try {
-                Thread.sleep(getReceiveTimeout());
-            } catch (InterruptedException ignore) {}
         }
 
         if (sharedConnection != null) {
@@ -297,12 +310,46 @@ public class ServiceTaskManager {
             }
         }
 
-        if (activeTaskCount.get() > 0) {
-            log.warn("Unable to shutdown all polling tasks of service : " + serviceName);
-        }
-
         serviceTaskManagerState = STATE_STOPPED;
-        log.info("Task manager for service : " + serviceName + " shutdown");
+
+        if (activeTaskCount.get() > 0) {
+            log.warn("Jakarta Task Manager for service: " + serviceName + " stopped with " + activeTaskCount.get()
+                    + " active tasks remaining");
+        } else {
+            log.info("Successfully stopped the Jakarta Task Manager for service: " + serviceName);
+        }
+    }
+
+    /**
+     * Waits for the completion of all in-flight Jakarta tasks during a graceful shutdown.
+     * The method blocks until either all in-flight messages are processed or the graceful
+     * shutdown timer expires, whichever comes first. This ensures that message processing
+     * is completed as much as possible before shutting down the consumer. Also, to ensure
+     * the waiting loop doesn't run indefinitely due to unexpected conditions, a fallback
+     * check is also introduced.
+     *
+     * @param gracefulShutdownTimer the {@link GracefulShutdownTimer} instance controlling the shutdown timeout
+     */
+    private void waitForGracefulTaskCompletion(GracefulShutdownTimer gracefulShutdownTimer) {
+        long startTimeMillis = System.currentTimeMillis();
+        long timeoutMillis = gracefulShutdownTimer.getShutdownTimeoutMillis();
+
+        // If the server is shutting down, we wait until either all in-flight messages are done
+        // or the graceful shutdown timer expires (whichever comes first)
+        while (activeTaskCount.get() > 0 && !gracefulShutdownTimer.isExpired()) {
+            try {
+                Thread.sleep(getReceiveTimeout()); // wait until all in-flight messages are done
+            } catch (InterruptedException e) {}
+
+            // Safety check: Ensure the loop doesn't run indefinitely due to unexpected conditions.
+            // This fallback check ensures that if the timer somehow fails to expire as expected,
+            // the loop can still exit gracefully once the configured timeout period has elapsed.
+            if ((System.currentTimeMillis() - startTimeMillis) >= timeoutMillis) {
+                log.warn("Graceful shutdown timer elapsed. Exiting waiting loop to prevent "
+                        + "indefinite blocking.");
+                break;
+            }
+        }
     }
 
     /**

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQConstants.java
@@ -107,6 +107,7 @@ public class RabbitMQConstants {
     public static final String MESSAGE_REQUEUE_DELAY = "rabbitmq.message.requeue.delay";
 
     public static final String PUBLISHER_CONFIRMS_ENABLED = "rabbitmq.publisher.confirms.enabled";
+    public static final String UNDEPLOYMENT_GRACE_TIMEOUT = "rabbitmq.undeployment.grace.timeout";
 
     public static final String DEFAULT_CONTENT_TYPE = "text/plain";
     public static final int DEFAULT_RETRY_INTERVAL = 30000;

--- a/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQListener.java
+++ b/modules/rabbitmq/src/main/java/org/apache/axis2/transport/rabbitmq/RabbitMQListener.java
@@ -21,6 +21,7 @@ package org.apache.axis2.transport.rabbitmq;
 
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.transport.base.AbstractTransportListenerEx;
+import org.apache.axis2.transport.base.BaseConstants;
 import org.wso2.securevault.SecretResolver;
 
 /**
@@ -94,7 +95,8 @@ public class RabbitMQListener extends AbstractTransportListenerEx<RabbitMQEndpoi
         if (log.isDebugEnabled()) {
             log.debug("Stopping receiver for for service : " + stm.getServiceName());
         }
-        stm.stop();
+        boolean listenerShuttingDown = (state == BaseConstants.STOPPED);
+        stm.stop(listenerShuttingDown);
         log.info("Stopped listening for AMQP messages to service : " + endpoint.getServiceName());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -675,7 +675,7 @@
     </build>
     <properties>
         <axis2.transports.version>2.0.0-wso2v76-SNAPSHOT</axis2.transports.version>
-        <axis2.version>1.6.1-wso2v109</axis2.version>
+        <axis2.version>1.6.1-wso2v111</axis2.version>
         <carbon.kernel.version>4.6.2</carbon.kernel.version>
         <imp.pkg.version.axis2>[1.6.1, 1.7.0)</imp.pkg.version.axis2>
         <imp.pkg.version.axiom>[1.2.11, 1.3.0)</imp.pkg.version.axiom>


### PR DESCRIPTION
This PR updates the shutdown logic to ensure that tasks in progress are given a chance to complete before proceeding with server shutdown.

During graceful shutdown, the logic now waits until either:
- All active tasks (activeTaskCount) are completed, or
- The GracefulShutdownTimer expires.

Fixes https://github.com/wso2/product-micro-integrator/issues/4385

