### PR TITLE
Enhance JMS error handling by adding transaction rollback recovery and session recreation logic.

### DIFF
--- a/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
+++ b/modules/jms/src/main/java/org/apache/axis2/transport/jms/ServiceTaskManager.java
@@ -41,6 +41,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.Session;
+import javax.jms.TransactionRolledBackException;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -765,6 +766,9 @@ public class ServiceTaskManager {
                     consumerRetryCount = 0;
                     return msg;
                 }
+            } catch (TransactionRolledBackException e) {
+                log.warn("Session transaction has been rolled back. Recreating JMS session.");
+                recreateSession();
             } catch (IllegalStateException e) {
                 // probably the consumer (shared) was closed.. which is still ok.. as we didn't read
                 connectionReceivedError = true;
@@ -788,6 +792,26 @@ public class ServiceTaskManager {
                 logError("Error receiving message for service : " + serviceName, e);
             }
             return null;
+        }
+
+        private synchronized void recreateSession() {
+            if (log.isDebugEnabled()) {
+                log.debug("Closing dead JMS consumer and session.");
+            }
+
+            if (consumer != null) {
+                closeConsumer(true);
+            }
+            if (session != null) {
+                closeSession(true);
+            }
+
+            session  = createSession();
+            consumer = createConsumer();
+
+            if (log.isDebugEnabled()) {
+                log.debug("JMS session recreated successfully.");
+            }
         }
 
         /**
@@ -1355,7 +1379,7 @@ public class ServiceTaskManager {
             }
 
             try {
-                context = getInitialContext();
+                context = getInitialContext(jmsProperties);
                 return
                     JMSUtils.lookup(context, UserTransaction.class, getUserTransactionJNDIName());
             } catch (NamingException e) {
@@ -1366,7 +1390,7 @@ public class ServiceTaskManager {
         
         if (sharedUserTransaction == null) {
             try {
-                context = getInitialContext();
+                context = getInitialContext(jmsProperties);
                 sharedUserTransaction =
                     JMSUtils.lookup(context, UserTransaction.class, getUserTransactionJNDIName());
                 if (log.isDebugEnabled()) {


### PR DESCRIPTION
This pull request improves the resilience and correctness of the JMS service task management by handling session transaction rollbacks more gracefully and ensuring proper context initialization when retrieving user transactions. The most important changes are grouped below:

**JMS Session Recovery and Error Handling:**

* Added handling for `TransactionRolledBackException` in the `receiveMessage()` method, logging a warning and recreating the JMS session and consumer to recover from transaction rollbacks.
* Introduced a new synchronized `recreateSession()` method that safely closes and recreates the JMS session and consumer when needed, with appropriate debug logging.
* Imported `TransactionRolledBackException` to support the new error handling logic.

**User Transaction Context Initialization:**

* Updated `getUserTransaction()` to use `getInitialContext(jmsProperties)` instead of the parameterless version, ensuring the correct context is used for JNDI lookups. 

Fixes: https://github.com/wso2/product-integrator-mi/issues/4758